### PR TITLE
docs: format rules descriptions consistently marking methods with “`”

### DIFF
--- a/.changeset/soft-moments-sink.md
+++ b/.changeset/soft-moments-sink.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod-x': patch
+---
+
+docs: format rules descriptions consistently marking methods with “`”

--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
-| Name                                                                               | Description                                                               | 💼  | 🔧  | 💡  |
-| :--------------------------------------------------------------------------------- | :------------------------------------------------------------------------ | :-- | :-- | :-- |
-| [array-style](docs/rules/array-style.md)                                           | Enforce consistent Zod array style                                        | ✅  | 🔧  |     |
-| [consistent-import-source](docs/rules/consistent-import-source.md)                 | Enforce consistent source from Zod imports                                |     |     |     |
-| [no-any](docs/rules/no-any.md)                                                     | Disallow usage of z.any() in Zod schemas                                  | ✅  |     | 💡  |
-| [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                     | Disallow usage of z.custom() without arguments                            | ✅  |     |     |
-| [no-number-schema-with-int](docs/rules/no-number-schema-with-int.md)               | Disallow usage of `z.number().int()` as it is considered legacy           | ✅  | 🔧  |     |
-| [no-optional-and-default-together](docs/rules/no-optional-and-default-together.md) | Disallow using both `.optional()` and `.default()` on the same Zod schema | ✅  | 🔧  |     |
-| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                             | Disallow throwing errors directly inside Zod refine callbacks             | ✅  |     |     |
-| [prefer-meta](docs/rules/prefer-meta.md)                                           | Enforce usage of .meta() over .describe()                                 | ✅  | 🔧  |     |
-| [prefer-meta-last](docs/rules/prefer-meta-last.md)                                 | Enforce .meta() as last method                                            | ✅  | 🔧  |     |
-| [prefer-namespace-import](docs/rules/prefer-namespace-import.md)                   | Enforce importing zod as a namespace import (import \* as z from 'zod')   | ✅  | 🔧  |     |
-| [prefer-strict-object](docs/rules/prefer-strict-object.md)                         | Enforce usage of .strictObject() over .object() and/or .looseObject()     |     |     |     |
-| [require-error-message](docs/rules/require-error-message.md)                       | Enforce that custom refinements include an error message                  | ✅  | 🔧  |     |
-| [require-schema-suffix](docs/rules/require-schema-suffix.md)                       | Require schema suffix when declaring a Zod schema                         | ✅  | 🔧  |     |
+| Name                                                                               | Description                                                                 | 💼  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [array-style](docs/rules/array-style.md)                                           | Enforce consistent Zod array style                                          | ✅  | 🔧  |     |
+| [consistent-import-source](docs/rules/consistent-import-source.md)                 | Enforce consistent source from Zod imports                                  |     |     |     |
+| [no-any](docs/rules/no-any.md)                                                     | Disallow usage of `z.any()` in Zod schemas                                  | ✅  |     | 💡  |
+| [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                     | Disallow usage of `z.custom()` without arguments                            | ✅  |     |     |
+| [no-number-schema-with-int](docs/rules/no-number-schema-with-int.md)               | Disallow usage of `z.number().int()` as it is considered legacy             | ✅  | 🔧  |     |
+| [no-optional-and-default-together](docs/rules/no-optional-and-default-together.md) | Disallow using both `.optional()` and `.default()` on the same Zod schema   | ✅  | 🔧  |     |
+| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                             | Disallow throwing errors directly inside Zod refine callbacks               | ✅  |     |     |
+| [prefer-meta](docs/rules/prefer-meta.md)                                           | Enforce usage of `.meta()` over `.describe()`                               | ✅  | 🔧  |     |
+| [prefer-meta-last](docs/rules/prefer-meta-last.md)                                 | Enforce `.meta()` as last method                                            | ✅  | 🔧  |     |
+| [prefer-namespace-import](docs/rules/prefer-namespace-import.md)                   | Enforce importing zod as a namespace import (`import * as z from 'zod'`)    | ✅  | 🔧  |     |
+| [prefer-strict-object](docs/rules/prefer-strict-object.md)                         | Enforce usage of `.strictObject()` over `.object()` and/or `.looseObject()` |     |     |     |
+| [require-error-message](docs/rules/require-error-message.md)                       | Enforce that custom refinements include an error message                    | ✅  | 🔧  |     |
+| [require-schema-suffix](docs/rules/require-schema-suffix.md)                       | Require schema suffix when declaring a Zod schema                           | ✅  | 🔧  |     |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/no-any.md
+++ b/docs/rules/no-any.md
@@ -1,4 +1,4 @@
-# Disallow usage of z.any() in Zod schemas (`zod-x/no-any`)
+# Disallow usage of `z.any()` in Zod schemas (`zod-x/no-any`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/no-empty-custom-schema.md
+++ b/docs/rules/no-empty-custom-schema.md
@@ -1,4 +1,4 @@
-# Disallow usage of z.custom() without arguments (`zod-x/no-empty-custom-schema`)
+# Disallow usage of `z.custom()` without arguments (`zod-x/no-empty-custom-schema`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/prefer-meta-last.md
+++ b/docs/rules/prefer-meta-last.md
@@ -1,4 +1,4 @@
-# Enforce .meta() as last method (`zod-x/prefer-meta-last`)
+# Enforce `.meta()` as last method (`zod-x/prefer-meta-last`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/prefer-meta.md
+++ b/docs/rules/prefer-meta.md
@@ -1,4 +1,4 @@
-# Enforce usage of .meta() over .describe() (`zod-x/prefer-meta`)
+# Enforce usage of `.meta()` over `.describe()` (`zod-x/prefer-meta`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/prefer-namespace-import.md
+++ b/docs/rules/prefer-namespace-import.md
@@ -1,4 +1,4 @@
-# Enforce importing zod as a namespace import (import \* as z from 'zod') (`zod-x/prefer-namespace-import`)
+# Enforce importing zod as a namespace import (`import * as z from 'zod'`) (`zod-x/prefer-namespace-import`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 

--- a/docs/rules/prefer-strict-object.md
+++ b/docs/rules/prefer-strict-object.md
@@ -1,4 +1,4 @@
-# Enforce usage of .strictObject() over .object() and/or .looseObject() (`zod-x/prefer-strict-object`)
+# Enforce usage of `.strictObject()` over `.object()` and/or `.looseObject()` (`zod-x/prefer-strict-object`)
 
 <!-- end auto-generated rule header -->
 

--- a/src/rules/no-any.ts
+++ b/src/rules/no-any.ts
@@ -10,12 +10,12 @@ export const noAny = ESLintUtils.RuleCreator(getRuleURL)({
     hasSuggestions: true,
     type: 'suggestion',
     docs: {
-      description: 'Disallow usage of z.any() in Zod schemas',
+      description: 'Disallow usage of `z.any()` in Zod schemas',
     },
     messages: {
       noZAny:
-        'Using z.any() is not allowed. Please use a more specific schema.',
-      useUnknown: 'Replace z.any() with z.unknown()',
+        'Using `z.any()` is not allowed. Please use a more specific schema.',
+      useUnknown: 'Replace `z.any()` with `z.unknown()`',
     },
     schema: [],
   },

--- a/src/rules/no-empty-custom-schema.ts
+++ b/src/rules/no-empty-custom-schema.ts
@@ -9,11 +9,11 @@ export const noEmptyCustomSchema = ESLintUtils.RuleCreator(getRuleURL)({
     hasSuggestions: false,
     type: 'suggestion',
     docs: {
-      description: 'Disallow usage of z.custom() without arguments',
+      description: 'Disallow usage of `z.custom()` without arguments',
     },
     messages: {
       noEmptyCustomSchema:
-        'You should provide a validate function within z.custom() ',
+        'You should provide a validate function within `z.custom()`',
     },
     schema: [],
   },

--- a/src/rules/prefer-meta-last.ts
+++ b/src/rules/prefer-meta-last.ts
@@ -9,11 +9,11 @@ export const preferMetaLast = ESLintUtils.RuleCreator(getRuleURL)({
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Enforce .meta() as last method',
+      description: 'Enforce `.meta()` as last method',
     },
     fixable: 'code',
     messages: {
-      metaNotLast: 'The .meta() methods should be the last one called',
+      metaNotLast: 'The `.meta()` methods should be the last one called',
     },
     schema: [],
   },

--- a/src/rules/prefer-meta.ts
+++ b/src/rules/prefer-meta.ts
@@ -9,11 +9,11 @@ export const preferMeta = ESLintUtils.RuleCreator(getRuleURL)({
     type: 'suggestion',
     fixable: 'code',
     docs: {
-      description: 'Enforce usage of .meta() over .describe()',
+      description: 'Enforce usage of `.meta()` over `.describe()`',
     },
     messages: {
       preferMeta:
-        'The .describe() method still exists for compatibility with Zod 3, but .meta() is now the recommended approach.',
+        'The `.describe()` method still exists for compatibility with Zod 3, but `.meta()` is now the recommended approach.',
     },
     schema: [],
   },

--- a/src/rules/prefer-namespace-import.ts
+++ b/src/rules/prefer-namespace-import.ts
@@ -17,7 +17,7 @@ export const preferNamespaceImport = ESLintUtils.RuleCreator(getRuleURL)({
     type: 'suggestion',
     docs: {
       description:
-        "Enforce importing zod as a namespace import (import * as z from 'zod')",
+        "Enforce importing zod as a namespace import (`import * as z from 'zod'`)",
     },
     fixable: 'code',
     messages: {

--- a/src/rules/prefer-strict-object.ts
+++ b/src/rules/prefer-strict-object.ts
@@ -21,10 +21,10 @@ export const preferStrictObjet = ESLintUtils.RuleCreator(getRuleURL)<
     type: 'suggestion',
     docs: {
       description:
-        'Enforce usage of .strictObject() over .object() and/or .looseObject()',
+        'Enforce usage of `.strictObject()` over `.object()` and/or `.looseObject()`',
     },
     messages: {
-      useStrictObject: 'Use .strictObject() instead of .{{method}}()',
+      useStrictObject: 'Use `.strictObject()` instead of `.{{method}}()`',
     },
     schema: [
       {


### PR DESCRIPTION
- Closes #62 