### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/.changeset/nasty-oranges-report.md
+++ b/.changeset/nasty-oranges-report.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod-x': patch
+---
+
+fix(array-style): disallow extra properties in rule options

--- a/.changeset/strong-phones-love.md
+++ b/.changeset/strong-phones-love.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod-x': patch
+---
+
+fix(prefer-strict-object): disallow extra properties in rule options

--- a/src/rules/array-style.ts
+++ b/src/rules/array-style.ts
@@ -32,7 +32,6 @@ export const arrayStyle = ESLintUtils.RuleCreator(getRuleURL)<
     schema: [
       {
         type: 'object',
-        additionalProperties: false,
         properties: {
           style: {
             description: 'Decides which style for zod array function',
@@ -40,6 +39,7 @@ export const arrayStyle = ESLintUtils.RuleCreator(getRuleURL)<
             enum: ['function', 'method'],
           },
         },
+        additionalProperties: false,
       },
     ],
   },

--- a/src/rules/prefer-strict-object.ts
+++ b/src/rules/prefer-strict-object.ts
@@ -29,7 +29,6 @@ export const preferStrictObjet = ESLintUtils.RuleCreator(getRuleURL)<
     schema: [
       {
         type: 'object',
-        additionalProperties: false,
         properties: {
           allow: {
             description: 'Decides which style for zod array function',
@@ -40,6 +39,7 @@ export const preferStrictObjet = ESLintUtils.RuleCreator(getRuleURL)<
             },
           },
         },
+        additionalProperties: false,
       },
     ],
   },


### PR DESCRIPTION
Some rules, for example [array-style](https://github.com/marcalexiei/eslint-plugin-zod-x/blob/32b46a15cfa921bf78891e6beff1b7aa9a05782e/src/rules/array-style.ts#L34) currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.