### PR TITLE
chore(issue_template/bug): remove `—system` flag from `npx envinfo`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -44,7 +44,7 @@ body:
     attributes:
       label: 💻 System info
       description: |
-        Output of `npx envinfo --system --npmPackages 'eslint,eslint-plugin-zod-x' --binaries`
+        Output of `npx envinfo --npmPackages 'eslint,eslint-plugin-zod-x' --binaries`
       render: shell
     validations:
       required: true


### PR DESCRIPTION
```diff
-  System:
-   OS: macOS 26.1
-    CPU: (8) arm64 Apple M3
-    Memory: 343.30 MB / 16.00 GB
-    Shell: 5.9 - /bin/zsh
   Binaries:
     Node: 24.11.1 - /path/v24.11.1/bin/node
     npm: 11.6.2 - /path/v24.11.1/bin/npm
     pnpm: 10.23.0 - /path/v24.11.1/bin/pnpm
   npmPackages:
     eslint: 9.39.1 => 9.39.1 
     eslint-plugin-zod-x: 1.12.0 => 1.12.0
```

System information aren't necessary