### PR TITLE
feat(prefer-namespace-import): deprecate rule in favour of `zod/consistent-import`

### DIFF
--- a/.changeset/funny-buses-write.md
+++ b/.changeset/funny-buses-write.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': minor
+---
+
+feat(prefer-namespace-import): deprecate rule in favour of `zod/consistent-import`

--- a/README.md
+++ b/README.md
@@ -26,28 +26,29 @@
 💼 Configurations enabled in.\
 ✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).\
+❌ Deprecated.
 
-| Name                                                                               | Description                                                                                   | 💼  | 🔧  | 💡  |
-| :--------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
-| [array-style](docs/rules/array-style.md)                                           | Enforce consistent Zod array style                                                            | ✅  | 🔧  |     |
-| [consistent-import](docs/rules/consistent-import.md)                               | Enforce a consistent import style for Zod                                                     |     | 🔧  |     |
-| [consistent-import-source](docs/rules/consistent-import-source.md)                 | Enforce consistent source from Zod imports                                                    |     |     | 💡  |
-| [consistent-object-schema-type](docs/rules/consistent-object-schema-type.md)       | Enforce consistent usage of Zod schema methods                                                |     |     | 💡  |
-| [no-any-schema](docs/rules/no-any-schema.md)                                       | Disallow usage of `z.any()` in Zod schemas                                                    | ✅  |     | 💡  |
-| [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                     | Disallow usage of `z.custom()` without arguments                                              | ✅  |     |     |
-| [no-number-schema-with-int](docs/rules/no-number-schema-with-int.md)               | Disallow usage of `z.number().int()` as it is considered legacy                               | ✅  | 🔧  |     |
-| [no-optional-and-default-together](docs/rules/no-optional-and-default-together.md) | Disallow using both `.optional()` and `.default()` on the same Zod schema                     | ✅  | 🔧  |     |
-| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                             | Disallow throwing errors directly inside Zod refine callbacks                                 | ✅  |     |     |
-| [no-unknown-schema](docs/rules/no-unknown-schema.md)                               | Disallow usage of `z.unknown()` in Zod schemas                                                |     |     |     |
-| [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)     | Prefer `z.enum()` over `z.union()` when all members are string literals.                      | ✅  | 🔧  |     |
-| [prefer-meta](docs/rules/prefer-meta.md)                                           | Enforce usage of `.meta()` over `.describe()`                                                 | ✅  | 🔧  |     |
-| [prefer-meta-last](docs/rules/prefer-meta-last.md)                                 | Enforce `.meta()` as last method                                                              | ✅  | 🔧  |     |
-| [prefer-namespace-import](docs/rules/prefer-namespace-import.md)                   | Enforce importing zod as a namespace import (`import * as z from 'zod'`)                      | ✅  | 🔧  |     |
-| [require-brand-type-parameter](docs/rules/require-brand-type-parameter.md)         | Require type parameter on `.brand()` functions                                                | ✅  |     | 💡  |
-| [require-error-message](docs/rules/require-error-message.md)                       | Enforce that custom refinements include an error message                                      | ✅  | 🔧  |     |
-| [require-schema-suffix](docs/rules/require-schema-suffix.md)                       | Require schema suffix when declaring a Zod schema                                             | ✅  |     |     |
-| [schema-error-property-style](docs/rules/schema-error-property-style.md)           | Enforce consistent style for error messages in Zod schema validation (using ESQuery patterns) |     |     |     |
+| Name                                                                               | Description                                                                                   | 💼  | 🔧  | 💡  | ❌  |
+| :--------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- |
+| [array-style](docs/rules/array-style.md)                                           | Enforce consistent Zod array style                                                            | ✅  | 🔧  |     |     |
+| [consistent-import](docs/rules/consistent-import.md)                               | Enforce a consistent import style for Zod                                                     | ✅  | 🔧  |     |     |
+| [consistent-import-source](docs/rules/consistent-import-source.md)                 | Enforce consistent source from Zod imports                                                    |     |     | 💡  |     |
+| [consistent-object-schema-type](docs/rules/consistent-object-schema-type.md)       | Enforce consistent usage of Zod schema methods                                                |     |     | 💡  |     |
+| [no-any-schema](docs/rules/no-any-schema.md)                                       | Disallow usage of `z.any()` in Zod schemas                                                    | ✅  |     | 💡  |     |
+| [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                     | Disallow usage of `z.custom()` without arguments                                              | ✅  |     |     |     |
+| [no-number-schema-with-int](docs/rules/no-number-schema-with-int.md)               | Disallow usage of `z.number().int()` as it is considered legacy                               | ✅  | 🔧  |     |     |
+| [no-optional-and-default-together](docs/rules/no-optional-and-default-together.md) | Disallow using both `.optional()` and `.default()` on the same Zod schema                     | ✅  | 🔧  |     |     |
+| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                             | Disallow throwing errors directly inside Zod refine callbacks                                 | ✅  |     |     |     |
+| [no-unknown-schema](docs/rules/no-unknown-schema.md)                               | Disallow usage of `z.unknown()` in Zod schemas                                                |     |     |     |     |
+| [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)     | Prefer `z.enum()` over `z.union()` when all members are string literals.                      | ✅  | 🔧  |     |     |
+| [prefer-meta](docs/rules/prefer-meta.md)                                           | Enforce usage of `.meta()` over `.describe()`                                                 | ✅  | 🔧  |     |     |
+| [prefer-meta-last](docs/rules/prefer-meta-last.md)                                 | Enforce `.meta()` as last method                                                              | ✅  | 🔧  |     |     |
+| [prefer-namespace-import](docs/rules/prefer-namespace-import.md)                   | Enforce importing zod as a namespace import (`import * as z from 'zod'`)                      |     | 🔧  |     | ❌  |
+| [require-brand-type-parameter](docs/rules/require-brand-type-parameter.md)         | Require type parameter on `.brand()` functions                                                | ✅  |     | 💡  |     |
+| [require-error-message](docs/rules/require-error-message.md)                       | Enforce that custom refinements include an error message                                      | ✅  | 🔧  |     |     |
+| [require-schema-suffix](docs/rules/require-schema-suffix.md)                       | Require schema suffix when declaring a Zod schema                                             | ✅  |     |     |     |
+| [schema-error-property-style](docs/rules/schema-error-property-style.md)           | Enforce consistent style for error messages in Zod schema validation (using ESQuery patterns) |     |     |     |     |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/consistent-import.md
+++ b/docs/rules/consistent-import.md
@@ -2,6 +2,8 @@
 
 📝 Enforce a consistent import style for Zod.
 
+💼 This rule is enabled in the ✅ `recommended` config.
+
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->

--- a/docs/rules/prefer-namespace-import.md
+++ b/docs/rules/prefer-namespace-import.md
@@ -2,11 +2,33 @@
 
 📝 Enforce importing zod as a namespace import (`import * as z from 'zod'`).
 
-💼 This rule is enabled in the ✅ `recommended` config.
+❌ This rule is deprecated.
 
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->
+
+## Deprecation notice
+
+Use `zod/consistent-import` instead:
+
+```diff
+  // eslint.config.js
+  import { defineConfig } from 'eslint/config';
+  import eslintPluginZod from 'eslint-plugin-zod';
+
+  export default defineConfig(
+    {
+      plugins: {
+        'zod-x': eslintPluginZodX,
+      },
+      rules: {
+-       'zod/prefer-namespace-import': 'error',
++       'zod/consistent-import': 'error',
+      }
+    }
+  );
+```
 
 ## Rule Details
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ const recommendedConfig = {
   },
   rules: {
     'zod/array-style': 'error',
+    'zod/consistent-import': 'error',
     'zod/no-any-schema': 'error',
     'zod/no-empty-custom-schema': 'error',
     'zod/no-number-schema-with-int': 'error',
@@ -79,7 +80,6 @@ const recommendedConfig = {
     'zod/prefer-enum-over-literal-union': 'error',
     'zod/prefer-meta': 'error',
     'zod/prefer-meta-last': 'error',
-    'zod/prefer-namespace-import': 'error',
     'zod/require-brand-type-parameter': 'error',
     'zod/require-error-message': 'error',
     'zod/require-schema-suffix': 'error',

--- a/src/rules/prefer-namespace-import.ts
+++ b/src/rules/prefer-namespace-import.ts
@@ -78,6 +78,9 @@ export const preferNamespaceImport = ESLintUtils.RuleCreator(getRuleURL)({
   name: 'prefer-namespace-import',
   meta: {
     type: 'suggestion',
+    deprecated: {
+      message: "Use `zod/consistent-import` with `{ syntax: 'namespace' }`",
+    },
     docs: {
       description:
         "Enforce importing zod as a namespace import (`import * as z from 'zod'`)",


### PR DESCRIPTION
- closes #180 