### PR TITLE
feat: add `prefer-string-schema-with-trim` rule to enforce `.trim()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 | [prefer-meta](docs/rules/prefer-meta.md)                                           | Enforce usage of `.meta()` over `.describe()`                                                 | ✅  | 🔧  |     |     |
 | [prefer-meta-last](docs/rules/prefer-meta-last.md)                                 | Enforce `.meta()` as last method                                                              | ✅  | 🔧  |     |     |
 | [prefer-namespace-import](docs/rules/prefer-namespace-import.md)                   | Enforce importing zod as a namespace import (`import * as z from 'zod'`)                      |     | 🔧  |     | ❌  |
+| [prefer-string-schema-with-trim](docs/rules/prefer-string-schema-with-trim.md)     | Require `z.string().trim()` to prevent accidental leading/trailing whitespace                 | ✅  | 🔧  |     |     |
 | [require-brand-type-parameter](docs/rules/require-brand-type-parameter.md)         | Require type parameter on `.brand()` functions                                                | ✅  |     | 💡  |     |
 | [require-error-message](docs/rules/require-error-message.md)                       | Enforce that custom refinements include an error message                                      | ✅  | 🔧  |     |     |
 | [require-schema-suffix](docs/rules/require-schema-suffix.md)                       | Require schema suffix when declaring a Zod schema                                             | ✅  |     |     |     |

--- a/docs/rules/prefer-string-schema-with-trim.md
+++ b/docs/rules/prefer-string-schema-with-trim.md
@@ -1,0 +1,51 @@
+# zod/prefer-string-schema-with-trim
+
+📝 Require `z.string().trim()` to prevent accidental leading/trailing whitespace.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+When defining string schemas, it is very common to require the string not to have leading or trailing whitespaces. Zod provides `.trim()` on `z.string()` to accomplish this. Failing to trim strings from user inputs or other boundaries might lead to issues like spaces affecting validation or database storage.
+
+This rule enforces adding `.trim()` to any `z.string()` schema to improve robustness.
+
+## Rule Details
+
+This rule reports an error when `z.string()` lacks `.trim()`.
+
+It includes an auto-fixer, which appends `.trim()` to the end of the schema definition chain.
+
+### ❌ Incorrect
+
+```ts
+import { z } from 'zod';
+
+const schema = z.string();
+```
+
+```ts
+import { z } from 'zod';
+
+const schema = z.string().min(1);
+```
+
+### ✅ Correct
+
+```ts
+import { z } from 'zod';
+
+const schema = z.string().trim();
+```
+
+```ts
+import { z } from 'zod';
+
+const schema = z.string().min(1).trim();
+```
+
+## Further Reading
+
+- [Zod Strings \`trim()\`](https://zod.dev/api#strings)

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { preferEnumOverLiteralUnion } from './rules/prefer-enum-over-literal-uni
 import { preferMetaLast } from './rules/prefer-meta-last.js';
 import { preferMeta } from './rules/prefer-meta.js';
 import { preferNamespaceImport } from './rules/prefer-namespace-import.js';
+import { preferStringSchemaWithTrim } from './rules/prefer-string-schema-with-trim.js';
 import { requireBrandTypeParameter } from './rules/require-brand-type-parameter.js';
 import { requireErrorMessage } from './rules/require-error-message.js';
 import { requireSchemaSuffix } from './rules/require-schema-suffix.js';
@@ -60,6 +61,7 @@ const eslintPluginZod = {
     'require-error-message': requireErrorMessage,
     'require-schema-suffix': requireSchemaSuffix,
     'schema-error-property-style': schemaErrorPropertyStyle,
+    'prefer-string-schema-with-trim': preferStringSchemaWithTrim,
     /* eslint-enable @typescript-eslint/naming-convention */
   } as unknown as Record<string, Rule.RuleModule>,
 } satisfies ESLint.Plugin as CompatiblePlugin;
@@ -83,6 +85,7 @@ const recommendedConfig = {
     'zod/prefer-enum-over-literal-union': 'error',
     'zod/prefer-meta': 'error',
     'zod/prefer-meta-last': 'error',
+    'zod/prefer-string-schema-with-trim': 'error',
     'zod/require-brand-type-parameter': 'error',
     'zod/require-error-message': 'error',
     'zod/require-schema-suffix': 'error',

--- a/src/rules/prefer-string-schema-with-trim.spec.ts
+++ b/src/rules/prefer-string-schema-with-trim.spec.ts
@@ -1,0 +1,86 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { preferStringSchemaWithTrim } from './prefer-string-schema-with-trim.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-string-schema-with-trim', preferStringSchemaWithTrim, {
+  valid: [
+    {
+      code: `
+        import { z } from 'zod';
+        z.string().trim();
+      `,
+    },
+    {
+      code: `
+        import { z } from 'zod';
+        z.string().min(1).trim();
+      `,
+    },
+    {
+      code: `
+        import { z } from 'zod';
+        z.string().trim().email();
+      `,
+    },
+    {
+      code: `
+        import { number } from 'zod';
+        number();
+      `,
+    },
+    {
+      code: `
+        import * as zod from 'zod';
+        zod.string().trim();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import { z } from 'zod';
+        z.string();
+      `,
+      errors: [{ messageId: 'preferTrim' }],
+      output: `
+        import { z } from 'zod';
+        z.string().trim();
+      `,
+    },
+    {
+      code: `
+        import { z } from 'zod';
+        z.string().min(1);
+      `,
+      errors: [{ messageId: 'preferTrim' }],
+      output: `
+        import { z } from 'zod';
+        z.string().min(1).trim();
+      `,
+    },
+    {
+      code: `
+        import { z } from 'zod';
+        z.string({ required_error: "Must be a string" });
+      `,
+      errors: [{ messageId: 'preferTrim' }],
+      output: `
+        import { z } from 'zod';
+        z.string({ required_error: "Must be a string" }).trim();
+      `,
+    },
+    {
+      code: `
+        import * as zod from 'zod';
+        zod.string();
+      `,
+      errors: [{ messageId: 'preferTrim' }],
+      output: `
+        import * as zod from 'zod';
+        zod.string().trim();
+      `,
+    },
+  ],
+});

--- a/src/rules/prefer-string-schema-with-trim.ts
+++ b/src/rules/prefer-string-schema-with-trim.ts
@@ -1,0 +1,58 @@
+import { ESLintUtils } from '@typescript-eslint/utils';
+
+import { getRuleURL } from '../meta.js';
+import { trackZodSchemaImports } from '../utils/track-zod-schema-imports.js';
+
+export const preferStringSchemaWithTrim = ESLintUtils.RuleCreator(getRuleURL)({
+  name: 'prefer-string-schema-with-trim',
+  meta: {
+    fixable: 'code',
+    type: 'suggestion',
+    docs: {
+      description:
+        'Require `z.string().trim()` to prevent accidental leading/trailing whitespace',
+      url: 'https://zod.dev/api#strings',
+    },
+    messages: {
+      preferTrim: '`z.string()` schemas should use `.trim()`.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const {
+      importDeclarationListener,
+      detectZodSchemaRootNode,
+      collectZodChainMethods,
+    } = trackZodSchemaImports();
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+
+      CallExpression(node): void {
+        const zodSchemaMeta = detectZodSchemaRootNode(node);
+
+        if (zodSchemaMeta?.schemaType !== 'string') {
+          return;
+        }
+
+        const methods = collectZodChainMethods(node);
+        const hasTrim = methods.some((m) => m.name === 'trim');
+
+        if (hasTrim) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'preferTrim',
+          fix(fixer) {
+            const lastMethod = methods[methods.length - 1];
+            return fixer.insertTextAfter(lastMethod.node, '.trim()');
+          },
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
I submitted this suggestion to PR.

close #209 