### PR TITLE
feat(rules): add Zod v4 number schema deprecation rules

### DIFF
--- a/.changeset/polite-bears-run.md
+++ b/.changeset/polite-bears-run.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': minor
+---
+
+feat(no-number-schema-with-step): add new rule

--- a/.changeset/quiet-tables-believe.md
+++ b/.changeset/quiet-tables-believe.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': minor
+---
+
+feat(no-number-schema-with-safe): add new rule

--- a/.changeset/smart-dishes-hunt.md
+++ b/.changeset/smart-dishes-hunt.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': minor
+---
+
+feat(no-number-schema-with-is-int): add new rule

--- a/.changeset/tidy-lions-smile.md
+++ b/.changeset/tidy-lions-smile.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': minor
+---
+
+feat(no-number-schema-with-is-finite): add new rule

--- a/.changeset/vast-mirrors-slide.md
+++ b/.changeset/vast-mirrors-slide.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': minor
+---
+
+feat(no-number-schema-with-finite): add new rule

--- a/README.md
+++ b/README.md
@@ -56,17 +56,22 @@ This plugin is primarily built for `zod`, so some rules are exclusive to `zod` a
 
 ### `zod` exclusive rules
 
-| Name                                                                               | Description                                                                                                              | 💼  | 🔧  | 💡  | ❌  |
-| :--------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- |
-| [array-style](docs/rules/array-style.md)                                           | Enforce consistent Zod array style                                                                                       | ✅  | 🔧  |     |     |
-| [no-number-schema-with-int](docs/rules/no-number-schema-with-int.md)               | Disallow usage of `z.number().int()` as it is considered legacy                                                          | ✅  | 🔧  |     |     |
-| [no-optional-and-default-together](docs/rules/no-optional-and-default-together.md) | Disallow using both `.optional()` and `.default()` on the same Zod schema                                                | ✅  | 🔧  |     |     |
-| [no-string-schema-with-uuid](docs/rules/no-string-schema-with-uuid.md)             | Disallow usage of `z.string().uuid()` in favor of the dedicated `z.uuid()` schema                                        | ✅  | 🔧  |     |     |
-| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                             | Disallow throwing errors directly inside Zod refine callbacks                                                            | ✅  |     |     |     |
-| [no-transform-in-record-key](docs/rules/no-transform-in-record-key.md)             | Disallow transforms in z.record() key schemas, which can cause silent key mutations and data loss through key collisions |     |     |     |     |
-| [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)     | Prefer `z.enum()` over `z.union()` when all members are string literals.                                                 | ✅  | 🔧  |     |     |
-| [prefer-meta-last](docs/rules/prefer-meta-last.md)                                 | Enforce `.meta()` as last method                                                                                         | ✅  | 🔧  |     |     |
-| [prefer-string-schema-with-trim](docs/rules/prefer-string-schema-with-trim.md)     | Enforce `z.string().trim()` to prevent accidental leading/trailing whitespace                                            | ✅  | 🔧  |     |     |
+| Name                                                                               | Description                                                                                                                    | 💼  | 🔧  | 💡  | ❌  |
+| :--------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- | :-- |
+| [array-style](docs/rules/array-style.md)                                           | Enforce consistent Zod array style                                                                                             | ✅  | 🔧  |     |     |
+| [no-number-schema-with-finite](docs/rules/no-number-schema-with-finite.md)         | Disallow deprecated `z.number().finite()`. In Zod 4+ number schemas do not allow infinite values by default, so it is a no-op. | ✅  | 🔧  |     |     |
+| [no-number-schema-with-int](docs/rules/no-number-schema-with-int.md)               | Disallow usage of `z.number().int()` as it is considered legacy                                                                | ✅  | 🔧  |     |     |
+| [no-number-schema-with-is-finite](docs/rules/no-number-schema-with-is-finite.md)   | Disallow using deprecated `isFinite` on a Zod number schema; in v4+ it is always `true`.                                       | ✅  |     |     |     |
+| [no-number-schema-with-is-int](docs/rules/no-number-schema-with-is-int.md)         | Disallow using deprecated `isInt` on a Zod number schema; check the `format` property instead.                                 | ✅  |     |     |     |
+| [no-number-schema-with-safe](docs/rules/no-number-schema-with-safe.md)             | Disallow deprecated `z.number().safe()`. Use `z.int()`; `.safe()` is now identical to `.int()`.                                | ✅  | 🔧  |     |     |
+| [no-number-schema-with-step](docs/rules/no-number-schema-with-step.md)             | Disallow deprecated `z.number().step()`. Use `.multipleOf()` instead.                                                          | ✅  | 🔧  |     |     |
+| [no-optional-and-default-together](docs/rules/no-optional-and-default-together.md) | Disallow using both `.optional()` and `.default()` on the same Zod schema                                                      | ✅  | 🔧  |     |     |
+| [no-string-schema-with-uuid](docs/rules/no-string-schema-with-uuid.md)             | Disallow usage of `z.string().uuid()` in favor of the dedicated `z.uuid()` schema                                              | ✅  | 🔧  |     |     |
+| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                             | Disallow throwing errors directly inside Zod refine callbacks                                                                  | ✅  |     |     |     |
+| [no-transform-in-record-key](docs/rules/no-transform-in-record-key.md)             | Disallow transforms in z.record() key schemas, which can cause silent key mutations and data loss through key collisions       |     |     |     |     |
+| [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)     | Prefer `z.enum()` over `z.union()` when all members are string literals.                                                       | ✅  | 🔧  |     |     |
+| [prefer-meta-last](docs/rules/prefer-meta-last.md)                                 | Enforce `.meta()` as last method                                                                                               | ✅  | 🔧  |     |     |
+| [prefer-string-schema-with-trim](docs/rules/prefer-string-schema-with-trim.md)     | Enforce `z.string().trim()` to prevent accidental leading/trailing whitespace                                                  | ✅  | 🔧  |     |     |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/no-number-schema-with-finite.md
+++ b/docs/rules/no-number-schema-with-finite.md
@@ -1,0 +1,41 @@
+# zod/no-number-schema-with-finite
+
+📝 Disallow deprecated `z.number().finite()`. In Zod 4+ number schemas do not allow infinite values by default, so it is a no-op.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+Zod 4+ rejects non-finite number values in `z.number()` schemas, so `z.number().finite()` is redundant. This rule disallows the deprecated call and the fixer removes it.
+
+## Examples
+
+### Invalid
+
+```ts
+import { z } from 'zod';
+
+z.number().finite();
+z.number().min(0).finite();
+```
+
+### Valid
+
+```ts
+import { z } from 'zod';
+
+z.number();
+z.number().min(0);
+```
+
+## When Not To Use It
+
+If you are on an older Zod version where `.finite()` is still meaningful, disable this rule.
+
+## Further Reading
+
+- [Zod v4 – Numbers](https://zod.dev/api?id=numbers)

--- a/docs/rules/no-number-schema-with-is-finite.md
+++ b/docs/rules/no-number-schema-with-is-finite.md
@@ -1,0 +1,38 @@
+# zod/no-number-schema-with-is-finite
+
+📝 Disallow using deprecated `isFinite` on a Zod number schema; in v4+ it is always `true`.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule flags property access to `isFinite` on `z.number()…` chain expressions, such as `z.number().isFinite` or `z.number().min(0).isFinite`.
+
+## Examples
+
+### Invalid
+
+```ts
+import { z } from 'zod';
+
+z.number().isFinite;
+z.number().min(0).isFinite;
+```
+
+### Valid
+
+```ts
+import { z } from 'zod';
+
+z.number();
+```
+
+## When Not To Use It
+
+If you need to support older Zod behavior or the rule’s pattern matching is too strict for your code, you can disable it locally.
+
+## Further Reading
+
+- [Zod v4 – Numbers](https://zod.dev/api?id=numbers)

--- a/docs/rules/no-number-schema-with-is-int.md
+++ b/docs/rules/no-number-schema-with-is-int.md
@@ -1,0 +1,38 @@
+# zod/no-number-schema-with-is-int
+
+📝 Disallow using deprecated `isInt` on a Zod number schema; check the `format` property instead.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule flags property access to `isInt` on expressions the plugin recognizes as a `z.number()…` chain (for example `z.number().isInt` or `z.number().min(0).isInt`).
+
+## Examples
+
+### Invalid
+
+```ts
+import { z } from 'zod';
+
+z.number().isInt;
+z.number().min(0).isInt;
+```
+
+### Valid
+
+```ts
+import { z } from 'zod';
+
+z.number();
+```
+
+## When Not To Use It
+
+If you read `isInt` in contexts this rule does not model (e.g. after assigning the schema to a variable), you may need to disable the rule for that line or file.
+
+## Further Reading
+
+- [Zod v4 – Numbers](https://zod.dev/api?id=numbers)

--- a/docs/rules/no-number-schema-with-safe.md
+++ b/docs/rules/no-number-schema-with-safe.md
@@ -1,0 +1,40 @@
+# zod/no-number-schema-with-safe
+
+📝 Disallow deprecated `z.number().safe()`. Use `z.int()`; `.safe()` is now identical to `.int()`.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule disallows `z.number().safe(...)` in favor of `z.int(...)` (with the same parameters where applicable), matching Zod’s migration guidance.
+
+## Examples
+
+### Invalid
+
+```ts
+import { z } from 'zod';
+
+z.number().safe();
+z.number().safe('message');
+```
+
+### Valid
+
+```ts
+import { z } from 'zod';
+
+z.int();
+```
+
+## When Not To Use It
+
+If you are stuck on a Zod version where the deprecation does not apply, you can turn this rule off.
+
+## Further Reading
+
+- [Zod v4 – Integers](https://zod.dev/api?id=integers)

--- a/docs/rules/no-number-schema-with-step.md
+++ b/docs/rules/no-number-schema-with-step.md
@@ -1,0 +1,41 @@
+# zod/no-number-schema-with-step
+
+📝 Disallow deprecated `z.number().step()`. Use `.multipleOf()` instead.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+The fixer renames the method from `step` to `multipleOf` and leaves arguments unchanged.
+
+## Examples
+
+### Invalid
+
+```ts
+import { z } from 'zod';
+
+z.number().step(0.1);
+z.number().min(0).step(2, 'error');
+```
+
+### Valid
+
+```ts
+import { z } from 'zod';
+
+z.number().multipleOf(0.1);
+z.number().min(0).multipleOf(2, 'error');
+```
+
+## When Not To Use It
+
+Disable this rule if you cannot migrate away from deprecated APIs yet.
+
+## Further Reading
+
+- [Zod v4 – Numbers](https://zod.dev/api?id=numbers)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,12 @@ import { consistentObjectSchemaType } from './rules/consistent-object-schema-typ
 import { consistentSchemaOutputTypeStyle } from './rules/consistent-schema-output-type-style.js';
 import { noAnySchema } from './rules/no-any-schema.js';
 import { noEmptyCustomSchema } from './rules/no-empty-custom-schema.js';
+import { noNumberSchemaWithFinite } from './rules/no-number-schema-with-finite.js';
 import { noNumberSchemaWithInt } from './rules/no-number-schema-with-int.js';
+import { noNumberSchemaWithIsFinite } from './rules/no-number-schema-with-is-finite.js';
+import { noNumberSchemaWithIsInt } from './rules/no-number-schema-with-is-int.js';
+import { noNumberSchemaWithSafe } from './rules/no-number-schema-with-safe.js';
+import { noNumberSchemaWithStep } from './rules/no-number-schema-with-step.js';
 import { noOptionalAndDefaultTogether } from './rules/no-optional-and-default-together.js';
 import { noStringSchemaWithUuid } from './rules/no-string-schema-with-uuid.js';
 import { noThrowInRefine } from './rules/no-throw-in-refine.js';
@@ -51,7 +56,12 @@ const eslintPluginZod = {
     'consistent-schema-output-type-style': consistentSchemaOutputTypeStyle,
     'no-any-schema': noAnySchema,
     'no-empty-custom-schema': noEmptyCustomSchema,
+    'no-number-schema-with-finite': noNumberSchemaWithFinite,
     'no-number-schema-with-int': noNumberSchemaWithInt,
+    'no-number-schema-with-is-finite': noNumberSchemaWithIsFinite,
+    'no-number-schema-with-is-int': noNumberSchemaWithIsInt,
+    'no-number-schema-with-safe': noNumberSchemaWithSafe,
+    'no-number-schema-with-step': noNumberSchemaWithStep,
     'no-string-schema-with-uuid': noStringSchemaWithUuid,
     'no-optional-and-default-together': noOptionalAndDefaultTogether,
     'no-throw-in-refine': noThrowInRefine,
@@ -86,7 +96,12 @@ const recommendedConfig = {
     'zod/consistent-import': 'error',
     'zod/no-any-schema': 'error',
     'zod/no-empty-custom-schema': 'error',
+    'zod/no-number-schema-with-finite': 'error',
     'zod/no-number-schema-with-int': 'error',
+    'zod/no-number-schema-with-is-finite': 'error',
+    'zod/no-number-schema-with-is-int': 'error',
+    'zod/no-number-schema-with-safe': 'error',
+    'zod/no-number-schema-with-step': 'error',
     'zod/no-string-schema-with-uuid': 'error',
     'zod/no-optional-and-default-together': 'error',
     'zod/no-throw-in-refine': 'error',

--- a/src/rules/no-number-schema-with-finite.spec.ts
+++ b/src/rules/no-number-schema-with-finite.spec.ts
@@ -1,0 +1,60 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { noNumberSchemaWithFinite } from './no-number-schema-with-finite.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-number-schema-with-finite', noNumberSchemaWithFinite, {
+  valid: [
+    {
+      name: 'number without .finite()',
+      code: dedent`
+        import * as z from 'zod';
+        z.number();
+      `,
+    },
+    {
+      name: 'unrelated to zod',
+      code: 'n.finite()',
+    },
+  ],
+  invalid: [
+    {
+      name: 'z.number().finite()',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().finite();
+      `,
+      errors: [{ messageId: 'removeFinite' }],
+      output: dedent`
+        import * as z from 'zod';
+        z.number();
+      `,
+    },
+    {
+      name: 'z.number().min(0).finite()',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().min(0).finite();
+      `,
+      errors: [{ messageId: 'removeFinite' }],
+      output: dedent`
+        import * as z from 'zod';
+        z.number().min(0);
+      `,
+    },
+    {
+      name: 'named import number().finite() — can fix',
+      code: dedent`
+        import { number } from 'zod';
+        number().finite();
+      `,
+      errors: [{ messageId: 'removeFinite' }],
+      output: dedent`
+        import { number } from 'zod';
+        number();
+      `,
+    },
+  ],
+});

--- a/src/rules/no-number-schema-with-finite.ts
+++ b/src/rules/no-number-schema-with-finite.ts
@@ -1,0 +1,68 @@
+import { buildZodChainRemoveMethodFix } from '../utils/build-zod-chain-remove-method-fix.js';
+import { createZodPluginRule } from '../utils/create-plugin-rule.js';
+import { createZodSchemaImportTrack } from '../utils/track-zod-schema-imports.js';
+
+const {
+  //
+  zodImportAllowedSource,
+  trackZodSchemaImports,
+} = createZodSchemaImportTrack('zod');
+
+export const noNumberSchemaWithFinite = createZodPluginRule({
+  name: 'no-number-schema-with-finite',
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      zodImportAllowedSource,
+      description:
+        'Disallow deprecated `z.number().finite()`. In Zod 4+ number schemas do not allow infinite values by default, so it is a no-op.',
+    },
+    messages: {
+      removeFinite:
+        '`.finite()` is deprecated. In Zod 4+ `z.number()` does not allow infinite values by default. Remove this call.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const {
+      importDeclarationListener,
+      detectZodSchemaRootNode,
+      collectZodChainMethods,
+    } = trackZodSchemaImports();
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+
+      CallExpression(node): void {
+        const zodSchemaMeta = detectZodSchemaRootNode(node);
+
+        if (zodSchemaMeta?.schemaType !== 'number') {
+          return;
+        }
+
+        const methods = collectZodChainMethods(node);
+        const finiteIndex = methods.findIndex(
+          (m) => m.name === 'finite' && m.node === node,
+        );
+        if (finiteIndex === -1) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'removeFinite',
+          fix(fixer) {
+            return buildZodChainRemoveMethodFix({
+              fixer,
+              methods,
+              removeIndex: finiteIndex,
+            });
+          },
+        });
+      },
+    };
+  },
+});

--- a/src/rules/no-number-schema-with-is-finite.spec.ts
+++ b/src/rules/no-number-schema-with-is-finite.spec.ts
@@ -1,0 +1,36 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { noNumberSchemaWithIsFinite } from './no-number-schema-with-is-finite.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-number-schema-with-is-finite', noNumberSchemaWithIsFinite, {
+  valid: [
+    {
+      name: 'z.number() without isFinite',
+      code: dedent`
+        import * as z from 'zod';
+        const n = z.number();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'z.number().isFinite',
+      code: dedent`
+        import * as z from 'zod';
+        void z.number().isFinite;
+      `,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      name: 'z.number().min(0).isFinite',
+      code: dedent`
+        import * as z from 'zod';
+        void z.number().min(0).isFinite;
+      `,
+      errors: [{ messageId: 'deprecated' }],
+    },
+  ],
+});

--- a/src/rules/no-number-schema-with-is-finite.ts
+++ b/src/rules/no-number-schema-with-is-finite.ts
@@ -1,0 +1,60 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createZodPluginRule } from '../utils/create-plugin-rule.js';
+import { createZodSchemaImportTrack } from '../utils/track-zod-schema-imports.js';
+
+const {
+  //
+  zodImportAllowedSource,
+  trackZodSchemaImports,
+} = createZodSchemaImportTrack('zod');
+
+export const noNumberSchemaWithIsFinite = createZodPluginRule({
+  name: 'no-number-schema-with-is-finite',
+  meta: {
+    type: 'problem',
+    docs: {
+      zodImportAllowedSource,
+      description:
+        'Disallow using deprecated `isFinite` on a Zod number schema; in v4+ it is always `true`.',
+    },
+    messages: {
+      deprecated:
+        '`isFinite` is deprecated. Number schemas no longer accept infinite values, so this is always `true` for `z.number()`.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const { importDeclarationListener, isZodNumberSchemaCallExpression } =
+      trackZodSchemaImports();
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+
+      MemberExpression(node): void {
+        if (node.computed) {
+          return;
+        }
+        if (node.property.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+        if (node.property.name !== 'isFinite') {
+          return;
+        }
+        if (node.object.type !== AST_NODE_TYPES.CallExpression) {
+          return;
+        }
+        if (!isZodNumberSchemaCallExpression(node.object)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'deprecated',
+        });
+      },
+    };
+  },
+});

--- a/src/rules/no-number-schema-with-is-int.spec.ts
+++ b/src/rules/no-number-schema-with-is-int.spec.ts
@@ -1,0 +1,40 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { noNumberSchemaWithIsInt } from './no-number-schema-with-is-int.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-number-schema-with-is-int', noNumberSchemaWithIsInt, {
+  valid: [
+    {
+      name: 'z.number() without isInt',
+      code: dedent`
+        import * as z from 'zod';
+        const n = z.number();
+      `,
+    },
+    {
+      name: 'isInt on non-zod',
+      code: 'const o = { isInt: true }; o.isInt',
+    },
+  ],
+  invalid: [
+    {
+      name: 'z.number().isInt',
+      code: dedent`
+        import * as z from 'zod';
+        const _x = z.number().isInt;
+      `,
+      errors: [{ messageId: 'useFormat' }],
+    },
+    {
+      name: 'z.number().min(0).isInt',
+      code: dedent`
+        import * as z from 'zod';
+        void z.number().min(0).isInt;
+      `,
+      errors: [{ messageId: 'useFormat' }],
+    },
+  ],
+});

--- a/src/rules/no-number-schema-with-is-int.ts
+++ b/src/rules/no-number-schema-with-is-int.ts
@@ -1,0 +1,60 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createZodPluginRule } from '../utils/create-plugin-rule.js';
+import { createZodSchemaImportTrack } from '../utils/track-zod-schema-imports.js';
+
+const {
+  //
+  zodImportAllowedSource,
+  trackZodSchemaImports,
+} = createZodSchemaImportTrack('zod');
+
+export const noNumberSchemaWithIsInt = createZodPluginRule({
+  name: 'no-number-schema-with-is-int',
+  meta: {
+    type: 'problem',
+    docs: {
+      zodImportAllowedSource,
+      description:
+        'Disallow using deprecated `isInt` on a Zod number schema; check the `format` property instead.',
+    },
+    messages: {
+      useFormat:
+        '`isInt` is deprecated. Check the `format` property on the number schema instead (or compare to `"int"` or `"float"`).',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const { importDeclarationListener, isZodNumberSchemaCallExpression } =
+      trackZodSchemaImports();
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+
+      MemberExpression(node): void {
+        if (node.computed) {
+          return;
+        }
+        if (node.property.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+        if (node.property.name !== 'isInt') {
+          return;
+        }
+        if (node.object.type !== AST_NODE_TYPES.CallExpression) {
+          return;
+        }
+        if (!isZodNumberSchemaCallExpression(node.object)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'useFormat',
+        });
+      },
+    };
+  },
+});

--- a/src/rules/no-number-schema-with-safe.spec.ts
+++ b/src/rules/no-number-schema-with-safe.spec.ts
@@ -1,0 +1,53 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { noNumberSchemaWithSafe } from './no-number-schema-with-safe.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-number-schema-with-safe', noNumberSchemaWithSafe, {
+  valid: [
+    {
+      name: 'z.int()',
+      code: dedent`
+        import * as z from 'zod';
+        z.int();
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'z.number().safe()',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().safe();
+      `,
+      errors: [{ messageId: 'useInt' }],
+      output: dedent`
+        import * as z from 'zod';
+        z.int();
+      `,
+    },
+    {
+      name: 'z.number().safe with message',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().safe('nope');
+      `,
+      errors: [{ messageId: 'useInt' }],
+      output: dedent`
+        import * as z from 'zod';
+        z.int('nope');
+      `,
+    },
+    {
+      name: 'named import number().safe() — no fix',
+      code: dedent`
+        import { number } from 'zod';
+        number().safe();
+      `,
+      errors: [{ messageId: 'useInt' }],
+      output: null,
+    },
+  ],
+});

--- a/src/rules/no-number-schema-with-safe.ts
+++ b/src/rules/no-number-schema-with-safe.ts
@@ -1,0 +1,83 @@
+import { buildZodChainReplacementFix } from '../utils/build-zod-chain-replacement-fix.js';
+import { createZodPluginRule } from '../utils/create-plugin-rule.js';
+import { createZodSchemaImportTrack } from '../utils/track-zod-schema-imports.js';
+
+const {
+  //
+  zodImportAllowedSource,
+  trackZodSchemaImports,
+} = createZodSchemaImportTrack('zod');
+
+export const noNumberSchemaWithSafe = createZodPluginRule({
+  name: 'no-number-schema-with-safe',
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      zodImportAllowedSource,
+      description:
+        'Disallow deprecated `z.number().safe()`. Use `z.int()`; `.safe()` is now identical to `.int()`.',
+    },
+    messages: {
+      useInt:
+        '`.safe()` is deprecated; it is identical to `.int()`. Use `z.int()` (or the equivalent) instead of chaining `.safe()` on `z.number()`.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const { sourceCode } = context;
+
+    const {
+      importDeclarationListener,
+      detectZodSchemaRootNode,
+      collectZodChainMethods,
+    } = trackZodSchemaImports();
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+
+      CallExpression(node): void {
+        const zodSchemaMeta = detectZodSchemaRootNode(node);
+
+        if (zodSchemaMeta?.schemaType !== 'number') {
+          return;
+        }
+
+        const methods = collectZodChainMethods(node);
+        const safeIndex = methods.findIndex(
+          (m) => m.name === 'safe' && m.node === node,
+        );
+        if (safeIndex === -1) {
+          return;
+        }
+
+        const numberIndex = methods.findIndex((m) => m.name === 'number');
+
+        if (zodSchemaMeta.schemaDecl === 'named') {
+          context.report({
+            node,
+            messageId: 'useInt',
+          });
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'useInt',
+          fix(fixer) {
+            return buildZodChainReplacementFix({
+              sourceCode,
+              fixer,
+              methods,
+              fromIndex: numberIndex,
+              toIndex: safeIndex,
+              toMethodName: 'int',
+            });
+          },
+        });
+      },
+    };
+  },
+});

--- a/src/rules/no-number-schema-with-step.spec.ts
+++ b/src/rules/no-number-schema-with-step.spec.ts
@@ -1,0 +1,56 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { noNumberSchemaWithStep } from './no-number-schema-with-step.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-number-schema-with-step', noNumberSchemaWithStep, {
+  valid: [
+    {
+      name: 'z.number() with multipleOf',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().multipleOf(2);
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'z.number().step(2)',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().step(2);
+      `,
+      errors: [{ messageId: 'useMultipleOf' }],
+      output: dedent`
+        import * as z from 'zod';
+        z.number().multipleOf(2);
+      `,
+    },
+    {
+      name: 'z.number().min(0).step(0.1, "err")',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().min(0).step(0.1, 'err');
+      `,
+      errors: [{ messageId: 'useMultipleOf' }],
+      output: dedent`
+        import * as z from 'zod';
+        z.number().min(0).multipleOf(0.1, 'err');
+      `,
+    },
+    {
+      name: 'number().step(1) named import',
+      code: dedent`
+        import { number } from 'zod';
+        number().step(1);
+      `,
+      errors: [{ messageId: 'useMultipleOf' }],
+      output: dedent`
+        import { number } from 'zod';
+        number().multipleOf(1);
+      `,
+    },
+  ],
+});

--- a/src/rules/no-number-schema-with-step.ts
+++ b/src/rules/no-number-schema-with-step.ts
@@ -1,0 +1,76 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createZodPluginRule } from '../utils/create-plugin-rule.js';
+import { createZodSchemaImportTrack } from '../utils/track-zod-schema-imports.js';
+
+const {
+  //
+  zodImportAllowedSource,
+  trackZodSchemaImports,
+} = createZodSchemaImportTrack('zod');
+
+export const noNumberSchemaWithStep = createZodPluginRule({
+  name: 'no-number-schema-with-step',
+  meta: {
+    fixable: 'code',
+    type: 'problem',
+    docs: {
+      zodImportAllowedSource,
+      description:
+        'Disallow deprecated `z.number().step()`. Use `.multipleOf()` instead.',
+    },
+    messages: {
+      useMultipleOf:
+        '`.step()` is deprecated. Use `.multipleOf()` with the same argument instead.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const {
+      importDeclarationListener,
+      detectZodSchemaRootNode,
+      collectZodChainMethods,
+    } = trackZodSchemaImports();
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+
+      CallExpression(node): void {
+        const zodSchemaMeta = detectZodSchemaRootNode(node);
+
+        if (zodSchemaMeta?.schemaType !== 'number') {
+          return;
+        }
+
+        const methods = collectZodChainMethods(node);
+        const stepIndex = methods.findIndex(
+          (m) => m.name === 'step' && m.node === node,
+        );
+        if (stepIndex === -1) {
+          return;
+        }
+
+        const { callee } = node;
+        if (
+          callee.type !== AST_NODE_TYPES.MemberExpression ||
+          callee.property.type !== AST_NODE_TYPES.Identifier ||
+          callee.property.name !== 'step'
+        ) {
+          return;
+        }
+
+        const { property } = callee;
+
+        context.report({
+          node,
+          messageId: 'useMultipleOf',
+          fix(fixer) {
+            return fixer.replaceText(property, 'multipleOf');
+          },
+        });
+      },
+    };
+  },
+});

--- a/src/utils/build-zod-chain-remove-method-fix.ts
+++ b/src/utils/build-zod-chain-remove-method-fix.ts
@@ -1,0 +1,28 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+
+/**
+ * Remove one call from a zod method chain, e.g. `z.number().min(0).finite()` →
+ * `z.number().min(0)`.
+ */
+export function buildZodChainRemoveMethodFix(opts: {
+  fixer: TSESLint.RuleFixer;
+  methods: Array<{ name: string; node: TSESTree.CallExpression }>;
+  removeIndex: number;
+}): TSESLint.RuleFix | null {
+  const { fixer, methods, removeIndex } = opts;
+
+  if (removeIndex < 1) {
+    return null;
+  }
+
+  // prettier-ignore
+  const prev = methods[removeIndex - 1]?.node as TSESTree.CallExpression | undefined;
+  // prettier-ignore
+  const toRemove = methods[removeIndex]?.node as TSESTree.CallExpression | undefined;
+
+  if (!prev?.range || !toRemove?.range) {
+    return null;
+  }
+
+  return fixer.removeRange([prev.range[1], toRemove.range[1]]);
+}

--- a/src/utils/detect-zod-schema-root-node.ts
+++ b/src/utils/detect-zod-schema-root-node.ts
@@ -173,6 +173,23 @@ function parseZodCallExpression(
   return null;
 }
 
+/**
+ * True when `node` is a zod number schema call chain (e.g. `z.number().min(1)`) or `number().min(1)`.
+ * Used for member access like `z.number().isInt` where the call is not the outermost expression
+ * in the file (so {@link detectZodSchemaRootNode} does not apply).
+ */
+export function isZodNumberSchemaCallExpression(
+  node: TSESTree.Node,
+  zodNamespaces: Set<string>,
+  zodNamedImports: { has: (key: string) => boolean },
+): boolean {
+  if (node.type !== AST_NODE_TYPES.CallExpression) {
+    return false;
+  }
+  const parsed = parseZodCallExpression(node, zodNamespaces, zodNamedImports);
+  return parsed !== null && parsed.schemaType === 'number';
+}
+
 /** Examine an expression (argument) for zod schema CallExpressions.
  * Supports:
  *  - direct CallExpression (string(), z.string(), etc)

--- a/src/utils/track-zod-schema-imports.ts
+++ b/src/utils/track-zod-schema-imports.ts
@@ -1,7 +1,10 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
-import { detectZodSchemaRootNode } from './detect-zod-schema-root-node.js';
+import {
+  detectZodSchemaRootNode,
+  isZodNumberSchemaCallExpression,
+} from './detect-zod-schema-root-node.js';
 import type { DetectResult } from './detect-zod-schema-root-node.js';
 import { isZodImportSource } from './is-zod-import-source.js';
 import type { ZodImportAllowedSource } from './is-zod-import-source.js';
@@ -63,6 +66,12 @@ interface Result {
   collectZodChainMethods: (
     node: TSESTree.CallExpression,
   ) => Array<ZodChainItem>;
+
+  /**
+   * True if `node` is a `z.number()…` (or `number()…`) zod call chain, including inner
+   * calls such as the object of `z.number().min(0).isInt`.
+   */
+  isZodNumberSchemaCallExpression: (node: TSESTree.Node) => boolean;
 }
 
 /**
@@ -164,6 +173,9 @@ function trackZodSchemaImports(
       detectZodSchemaRootNode(node, zodNamespaces, zodNamedImports),
 
     collectZodChainMethods,
+
+    isZodNumberSchemaCallExpression: (node) =>
+      isZodNumberSchemaCallExpression(node, zodNamespaces, zodNamedImports),
   };
 
   return result;


### PR DESCRIPTION
Add more deprecated errors no-number-schema-with-finite, -safe, -step, -is-int, and -is-finite. Include buildZodChainRemoveMethodFix, isZodNumberSchemaCallExpression for property checks, docs, and recommended config entries.

Just a note, this is all developed by Cursor so I have just reviewed the code. 
It is suppose to give errors on deprecated usages of `z.number()....` like in image below. 
I used the `@depracation` in the zod v4 code docs to let cursor know what rules to create.
I have not tested this yet but think the tests generated should be enough.
<img width="958" height="479" alt="image" src="https://github.com/user-attachments/assets/03c11786-ae93-4bb8-97cf-adcf0a9b151b" />
