### PR TITLE
fix: rules documentation reference now point to the installed tag rather than HEAD

### DIFF
--- a/.changeset/fair-houses-thank.md
+++ b/.changeset/fair-houses-thank.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': patch
+---
+
+fix: rules documentation reference now point to the installed tag rather than HEAD

--- a/src/meta.spec.ts
+++ b/src/meta.spec.ts
@@ -6,8 +6,8 @@ describe('getRuleURL', () => {
   /** @see https://github.com/marcalexiei/eslint-plugin-zod/pull/97 */
   it('should provide correct URLs (no hash please)', () => {
     const RULE_ID = 'rule-id-mock';
-    expect(getRuleURL(RULE_ID)).toBe(
-      `https://github.com/marcalexiei/eslint-plugin-zod/blob/HEAD/docs/rules/${RULE_ID}.md`,
+    expect(getRuleURL(RULE_ID)).toMatch(
+      /^https:\/\/github\.com\/marcalexiei\/eslint-plugin-zod\/blob\/v\d+\.\d+\.\d+\/docs\/rules\/rule-id-mock\.md$/,
     );
   });
 });

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -17,5 +17,6 @@ export { PLUGIN_NAME, PLUGIN_VERSION };
 const PLUGIN_HOMEPAGE = homepage.replace(/#[^#]*$/, '');
 
 export function getRuleURL(ruleID: string): string {
-  return `${PLUGIN_HOMEPAGE}/blob/HEAD/docs/rules/${ruleID}.md`;
+  // e.g., https://github.com/marcalexiei/eslint-plugin-zod/blob/v3.12.0/docs/rules/array-style.md
+  return `${PLUGIN_HOMEPAGE}/blob/v${PLUGIN_VERSION}/docs/rules/${ruleID}.md`;
 }


### PR DESCRIPTION
- Closes #268 