### PR TITLE
feat(eslint-plugin-zod-mini): add `prefer-enum-over-literal-union` rule

### DIFF
--- a/.changeset/bold-papayas-sniff.md
+++ b/.changeset/bold-papayas-sniff.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod-mini': minor
+---
+
+feat: add `prefer-enum-over-literal-union` rule

--- a/plugins/eslint-plugin-zod-mini/README.md
+++ b/plugins/eslint-plugin-zod-mini/README.md
@@ -41,6 +41,7 @@ Find out more about [Oxlint's `jsPLugins`](https://oxc.rs/docs/guide/usage/linte
 | [no-any-schema](docs/rules/no-any-schema.md)                                             | Disallow usage of `z.any()` in Zod Mini schemas                                                    | ✅  |     | 💡  |
 | [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                           | Disallow usage of `z.custom()` without arguments                                                   | ✅  |     |     |
 | [no-unknown-schema](docs/rules/no-unknown-schema.md)                                     | Disallow usage of `z.unknown()` in Zod Mini schemas                                                |     |     |     |
+| [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)           | Prefer `z.enum()` over `z.union()` when all members are string literals.                           | ✅  | 🔧  |     |
 | [prefer-meta](docs/rules/prefer-meta.md)                                                 | Enforce usage of `z.meta()` over `z.describe()`                                                    | ✅  | 🔧  |     |
 | [require-brand-type-parameter](docs/rules/require-brand-type-parameter.md)               | Require type parameter on `.brand()` functions                                                     | ✅  |     | 💡  |
 | [require-error-message](docs/rules/require-error-message.md)                             | Enforce that custom refinements include an error message                                           | ✅  | 🔧  |     |

--- a/plugins/eslint-plugin-zod-mini/docs/rules/prefer-enum-over-literal-union.md
+++ b/plugins/eslint-plugin-zod-mini/docs/rules/prefer-enum-over-literal-union.md
@@ -1,0 +1,96 @@
+# zod-mini/prefer-enum-over-literal-union
+
+📝 Prefer `z.enum()` over `z.union()` when all members are string literals.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This rule suggests replacing `z.union([...])` composed exclusively of `z.literal()` schemas with `z.enum([...])`.
+
+When all members of a union are string literals, `z.enum()` is the more idiomatic, concise, and intention-revealing Zod Mini construct.
+
+## Why?
+
+Using `z.enum()` instead of a union of literals:
+
+1. Results in clearer and more expressive schemas
+2. Reduces verbosity and repetition
+3. Aligns with Zod Mini best practices for enumerated values
+4. Improves readability by making the intent explicit
+
+From Zod Mini’s perspective, a union of string literals and an enum often represent the same domain concept, but `z.enum()` communicates that intent more directly.
+
+## Examples
+
+### ❌ Invalid
+
+```ts
+import * as z from 'zod/mini';
+
+z.union([z.literal('foo'), z.literal('bar')]);
+```
+
+```ts
+import * as zod from 'zod/mini';
+
+zod.union([zod.literal('foo'), zod.literal('bar')]);
+```
+
+### ✅ Valid
+
+```ts
+import * as z from 'zod/mini';
+
+z.enum(['foo', 'bar']);
+```
+
+```ts
+import * as z from 'zod/mini';
+
+// Non-literal members make enum invalid
+z.union([z.literal('foo'), z.literal('bar'), z.int()]);
+```
+
+## Autofix Behavior
+
+When all union members are `z.literal(<string>)` calls and the schema can be safely rewritten, this rule will automatically:
+
+- Replace `.union(...)` with `.enum(...)`
+- Extract and preserve the original literal values (including quote style)
+
+Example fix:
+
+```ts
+// Before
+z.union([z.literal('foo'), z.literal('bar')]);
+
+// After
+z.enum(['foo', 'bar']);
+```
+
+### Limitations
+
+Autofix is **not applied** when:
+
+- The union is referenced via named imports (e.g. `import { union, literal } from 'zod/mini'`)
+
+In these cases, the rule will still report but will not modify the code.
+
+## When Not To Use It
+
+You may want to disable this rule if:
+
+- You intentionally use `z.union()` for stylistic consistency
+- You rely on patterns where unions may later include non-literal members
+- Your codebase prefers explicit `z.literal()` unions for clarity or tooling reasons
+
+## Further Reading
+
+- [eslint-plugin-zod - prefer-enum](https://github.com/gajus/eslint-plugin-zod?tab=readme-ov-file#prefer-enum)
+- [Zod – Enums](https://zod.dev/api?id=enums)
+- [Zod – Literals](https://zod.dev/api?id=literals)

--- a/plugins/eslint-plugin-zod-mini/src/index.ts
+++ b/plugins/eslint-plugin-zod-mini/src/index.ts
@@ -9,6 +9,7 @@ import { consistentSchemaVarName } from './rules/consistent-schema-var-name.js';
 import { noAnySchema } from './rules/no-any-schema.js';
 import { noEmptyCustomSchema } from './rules/no-empty-custom-schema.js';
 import { noUnknownSchema } from './rules/no-unknown-schema.js';
+import { preferEnumOverLiteralUnion } from './rules/prefer-enum-over-literal-union.js';
 import { preferMeta } from './rules/prefer-meta.js';
 import { requireBrandTypeParameter } from './rules/require-brand-type-parameter.js';
 import { requireErrorMessage } from './rules/require-error-message.js';
@@ -41,6 +42,7 @@ const eslintPluginZodMini = {
     'no-any-schema': noAnySchema,
     'no-empty-custom-schema': noEmptyCustomSchema,
     'no-unknown-schema': noUnknownSchema,
+    'prefer-enum-over-literal-union': preferEnumOverLiteralUnion,
     'prefer-meta': preferMeta,
     'require-brand-type-parameter': requireBrandTypeParameter,
     'require-error-message': requireErrorMessage,
@@ -63,6 +65,7 @@ const recommendedConfig = {
     'zod-mini/consistent-schema-var-name': 'error',
     'zod-mini/no-any-schema': 'error',
     'zod-mini/no-empty-custom-schema': 'error',
+    'zod-mini/prefer-enum-over-literal-union': 'error',
     'zod-mini/prefer-meta': 'error',
     'zod-mini/require-brand-type-parameter': 'error',
     'zod-mini/require-error-message': 'error',

--- a/plugins/eslint-plugin-zod-mini/src/rules/prefer-enum-over-literal-union.spec.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/prefer-enum-over-literal-union.spec.ts
@@ -1,0 +1,167 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { preferEnumOverLiteralUnion } from './prefer-enum-over-literal-union.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(preferEnumOverLiteralUnion.name, preferEnumOverLiteralUnion, {
+  valid: [
+    {
+      name: 'namespace import',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.enum(['foo', 'bar'])
+      `,
+    },
+    {
+      name: 'named z import',
+      code: dedent`
+        import { z } from 'zod/mini';
+        z.enum(['foo', 'bar'])
+      `,
+    },
+    {
+      name: 'union with a non-literal element',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.union([z.literal('foo'), z.literal('bar'), z.int()])
+      `,
+    },
+    {
+      name: 'should error only for literal strings',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.union([z.literal('foo'), z.literal(5)])
+      `,
+    },
+    {
+      name: 'not triggered on zod import',
+      code: dedent`
+        import * as z from 'zod';
+        z.union([z.literal('foo'), z.literal('bar')])
+      `,
+    },
+    {
+      name: 'zod/v4-mini import',
+      code: dedent`
+        import * as z from 'zod/v4-mini';
+        z.enum(['foo', 'bar'])
+      `,
+    },
+    {
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.union([z.string(), z.number()])
+      `,
+    },
+    {
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.looseObject({
+          modifiedTime: z.optional(z.string()),
+          size: z.union([z.string(), z.number()]),
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'namespace import',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.union([z.literal('foo'), z.literal('bar')])
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: dedent`
+        import * as z from 'zod/mini';
+        z.enum(['foo', 'bar'])
+      `,
+    },
+    {
+      name: 'namespace import (keeps original string format)',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.union([z.literal("foo"), z.literal('bar')])
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: dedent`
+        import * as z from 'zod/mini';
+        z.enum(["foo", 'bar'])
+      `,
+    },
+    {
+      name: 'namespace import different from z',
+      code: dedent`
+        import * as zod from 'zod/mini';
+        zod.union([zod.literal('foo'), zod.literal('bar')])
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: dedent`
+        import * as zod from 'zod/mini';
+        zod.enum(['foo', 'bar'])
+      `,
+    },
+    {
+      name: 'named import',
+      code: dedent`
+        import { union, literal } from 'zod/mini';
+        union([literal('foo'), literal('bar')])
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: null,
+    },
+    {
+      name: 'named z import',
+      code: dedent`
+        import { z } from 'zod/mini';
+        z.union([z.literal('foo'), z.literal('bar')])
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: dedent`
+        import { z } from 'zod/mini';
+        z.enum(['foo', 'bar'])
+      `,
+    },
+    {
+      name: 'zod/v4-mini import',
+      code: dedent`
+        import * as z from 'zod/v4-mini';
+        z.union([z.literal('foo'), z.literal('bar')])
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: dedent`
+        import * as z from 'zod/v4-mini';
+        z.enum(['foo', 'bar'])
+      `,
+    },
+    {
+      name: 'with check method (namespace import)',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.union([z.literal('foo'), z.literal('bar')]).check(z.refine(() => true));
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: dedent`
+        import * as z from 'zod/mini';
+        z.enum(['foo', 'bar']).check(z.refine(() => true));
+      `,
+    },
+    {
+      name: 'nested (namespace import)',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.looseObject({
+          size: z.union([z.literal('foo'), z.literal('bar')]),
+        });
+      `,
+      errors: [{ messageId: 'useEnum' }],
+      output: dedent`
+        import * as z from 'zod/mini';
+        z.looseObject({
+          size: z.enum(['foo', 'bar']),
+        });
+      `,
+    },
+  ],
+});

--- a/plugins/eslint-plugin-zod-mini/src/rules/prefer-enum-over-literal-union.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/prefer-enum-over-literal-union.ts
@@ -1,0 +1,92 @@
+import { createZodSchemaImportTrack, zodMiniImportScope } from '@eslint-zod/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createZodMiniPluginRule } from '../utils/create-plugin-rule.js';
+
+const { trackZodSchemaImports } = createZodSchemaImportTrack(zodMiniImportScope);
+
+export const preferEnumOverLiteralUnion = createZodMiniPluginRule({
+  name: 'prefer-enum-over-literal-union',
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    docs: {
+      description: 'Prefer `z.enum()` over `z.union()` when all members are string literals.',
+    },
+    messages: {
+      useEnum: 'Replace this union of string literals with `z.enum()`.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const { importDeclarationListener, detectZodSchemaRootNode, collectZodChainMethods } =
+      trackZodSchemaImports();
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+      CallExpression(node): void {
+        const zodSchemaMeta = detectZodSchemaRootNode(node);
+
+        if (zodSchemaMeta?.schemaType !== 'union') {
+          return;
+        }
+
+        const methods = collectZodChainMethods(zodSchemaMeta.node);
+        const union = methods.find((it) => it.name === 'union');
+
+        if (!union) {
+          return;
+        }
+
+        const unionNode = union.node;
+
+        const unionArgument = unionNode.arguments.at(0);
+        if (unionArgument?.type !== AST_NODE_TYPES.ArrayExpression) {
+          return;
+        }
+
+        const zodLiteralStrings = unionArgument.elements.map<string | null>((s) => {
+          if (!s) {
+            return null;
+          }
+
+          const maybeLiteralSchema = detectZodSchemaRootNode(s);
+          if (maybeLiteralSchema?.schemaType !== 'literal') {
+            return null;
+          }
+
+          const [literalArgument] = maybeLiteralSchema.node.arguments;
+          if (
+            literalArgument.type === AST_NODE_TYPES.Literal &&
+            typeof literalArgument.value === 'string'
+          ) {
+            return literalArgument.raw;
+          }
+
+          return null;
+        });
+
+        if (zodLiteralStrings.some((it) => it === null)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'useEnum',
+          fix(fixer) {
+            if (zodSchemaMeta.schemaDecl === 'named') {
+              return null;
+            }
+
+            return [
+              fixer.replaceText((unionNode.callee as TSESTree.MemberExpression).property, 'enum'),
+              fixer.replaceText(unionNode.arguments[0], `[${zodLiteralStrings.join(', ')}]`),
+            ];
+          },
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Summary

Adds `zod-mini/prefer-enum-over-literal-union`, matching the existing `zod/prefer-enum-over-literal-union` behavior for Zod Mini.

## Changes

- Added the new Zod Mini rule implementation.
- Registered the rule in `eslint-plugin-zod-mini` and enabled it in the recommended config.
- Added tests covering namespace imports, named imports, `zod/v4-mini`, nested schemas, `.check()` chains, non-string literals, and autofix behavior.
- Added rule docs and regenerated the Zod Mini README rule table.