### PR TITLE
feat(eslint-plugin-zod-mini): add `no-throw-in-refine` rule

### DIFF
--- a/.changeset/every-mugs-exist.md
+++ b/.changeset/every-mugs-exist.md
@@ -1,0 +1,5 @@
+---
+'@eslint-zod/utils': minor
+---
+
+feat: add `no-throw-in-refine` rule builder

--- a/.changeset/petite-baths-speak.md
+++ b/.changeset/petite-baths-speak.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': patch
+---
+
+refactor(no-throw-in-refine): use `@eslint-zod/utils/rule-builders/no-throw-in-refine`

--- a/.changeset/polite-doodles-post.md
+++ b/.changeset/polite-doodles-post.md
@@ -1,0 +1,10 @@
+---
+'eslint-plugin-zod-mini': minor
+'eslint-plugin-zod': minor
+'@eslint-zod/utils': minor
+---
+
+feat: add `no-throw-in-refine` to Zod Mini and extract a shared rule builder
+
+The `no-throw-in-refine` create logic has been extracted into `@eslint-zod/utils` so both
+`eslint-plugin-zod` and `eslint-plugin-zod-mini` use the same shared implementation.

--- a/.changeset/polite-doodles-post.md
+++ b/.changeset/polite-doodles-post.md
@@ -1,10 +1,8 @@
 ---
 'eslint-plugin-zod-mini': minor
-'eslint-plugin-zod': minor
-'@eslint-zod/utils': minor
 ---
 
-feat: add `no-throw-in-refine` to Zod Mini and extract a shared rule builder
+feat(rule-builders): add `no-throw-in-refine`
 
 The `no-throw-in-refine` create logic has been extracted into `@eslint-zod/utils` so both
 `eslint-plugin-zod` and `eslint-plugin-zod-mini` use the same shared implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ Each plugin is scoped to its own import source via `ZodImportAllowedSource` (`'z
 - `@eslint-zod/utils` (`packages/utils/src/`) — AST parsing, import tracking, traversal, and fixer helpers
 - `@eslint-zod/utils/rule-builders/<rule-name>` (`packages/utils/src/rule-builders/`) — one export per shared rule builder; the file name matches the rule name (e.g. `consistent-import.ts` → `@eslint-zod/utils/rule-builders/consistent-import`)
 
-Available rule builder exports: `consistent-import`, `consistent-import-source`, `consistent-object-schema-type`, `consistent-schema-output-type-style`, `consistent-schema-var-name`, `no-any-schema`, `no-empty-custom-schema`, `no-unknown-schema`, `prefer-enum-over-literal-union`, `require-brand-type-parameter`, `require-error-message`, `schema-error-property-style`.
+Available rule builder exports: `consistent-import`, `consistent-import-source`, `consistent-object-schema-type`, `consistent-schema-output-type-style`, `consistent-schema-var-name`, `no-any-schema`, `no-empty-custom-schema`, `no-throw-in-refine`, `no-unknown-schema`, `prefer-enum-over-literal-union`, `require-brand-type-parameter`, `require-error-message`, `schema-error-property-style`.
 
 `IMPORT_SYNTAXES` and `ImportSyntax` are exported from `@eslint-zod/utils/rule-builders/consistent-import` (not from the root).
 
@@ -98,7 +98,7 @@ Several rules exist in both `eslint-plugin-zod` and `eslint-plugin-zod-mini` wit
 - **Docs** (`docs/rules/<rule-name>.md`): mirror structure and content, but adapt all code examples to the correct import source (`zod` vs `zod/mini`) and API style (chained methods vs standalone `$ZodCheck` functions passed to `.check()`).
 - **Specs** (`src/rules/<rule-name>.spec.ts`): mirror the test cases, but again adapt import sources and API. Valid/invalid cases should cover the same scenarios in both plugins.
 
-Rules that exist in both plugins: `consistent-import`, `consistent-import-source`, `consistent-object-schema-type`, `consistent-schema-output-type-style`, `consistent-schema-var-name`, `no-any-schema`, `no-empty-custom-schema`, `no-unknown-schema`, `prefer-enum-over-literal-union`, `prefer-meta`, `require-brand-type-parameter`, `require-error-message`, `schema-error-property-style`.
+Rules that exist in both plugins: `consistent-import`, `consistent-import-source`, `consistent-object-schema-type`, `consistent-schema-output-type-style`, `consistent-schema-var-name`, `no-any-schema`, `no-empty-custom-schema`, `no-throw-in-refine`, `no-unknown-schema`, `prefer-enum-over-literal-union`, `prefer-meta`, `require-brand-type-parameter`, `require-error-message`, `schema-error-property-style`.
 
 ## Quality expectations
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -59,6 +59,7 @@ These helpers return ESLint `create` functions parameterised by import scope so 
 - `buildConsistentSchemaVarNameCreate(scope)`
 - `buildNoAnySchemaCreate(scope)`
 - `buildNoEmptyCustomSchemaCreate(scope)`
+- `buildNoThrowInRefineCreate(scope)`
 - `buildNoUnknownSchemaCreate(scope)`
 - `buildPreferEnumOverLiteralUnionCreate(scope)`
 - `buildRequireBrandTypeParameterCreate(scope)`

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -67,6 +67,11 @@
       "import": "./dist/rule-builders/no-empty-custom-schema.mjs",
       "require": "./dist/rule-builders/no-empty-custom-schema.cjs"
     },
+    "./rule-builders/no-throw-in-refine": {
+      "@eslint-zod/source": "./src/rule-builders/no-throw-in-refine.ts",
+      "import": "./dist/rule-builders/no-throw-in-refine.mjs",
+      "require": "./dist/rule-builders/no-throw-in-refine.cjs"
+    },
     "./rule-builders/no-unknown-schema": {
       "@eslint-zod/source": "./src/rule-builders/no-unknown-schema.ts",
       "import": "./dist/rule-builders/no-unknown-schema.mjs",

--- a/packages/utils/src/rule-builders/no-throw-in-refine.ts
+++ b/packages/utils/src/rule-builders/no-throw-in-refine.ts
@@ -1,0 +1,90 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createZodSchemaImportTrack } from '../track-zod-schema-imports.js';
+import type { ZodImportScope } from '../zod-import-scope.js';
+
+type MessageIds = 'noThrowInRefine';
+
+export function buildNoThrowInRefineCreate(
+  scope: ZodImportScope,
+): (context: Readonly<TSESLint.RuleContext<MessageIds, []>>) => TSESLint.RuleListener {
+  const { trackZodSchemaImports } = createZodSchemaImportTrack(scope);
+
+  return function create(context) {
+    const { importDeclarationListener, detectZodSchemaRootNode, collectZodChainMethods } =
+      trackZodSchemaImports();
+
+    function checkNode(node: TSESTree.Node | null): void {
+      if (!node) {
+        return;
+      }
+
+      switch (node.type) {
+        case AST_NODE_TYPES.ThrowStatement:
+          context.report({ node, messageId: 'noThrowInRefine' });
+          break;
+        case AST_NODE_TYPES.BlockStatement:
+          node.body.forEach(checkNode);
+          break;
+        case AST_NODE_TYPES.IfStatement:
+          checkNode(node.consequent);
+          if (node.alternate) {
+            checkNode(node.alternate);
+          }
+          break;
+        case AST_NODE_TYPES.ForStatement:
+        case AST_NODE_TYPES.ForInStatement:
+        case AST_NODE_TYPES.ForOfStatement:
+        case AST_NODE_TYPES.WhileStatement:
+        case AST_NODE_TYPES.DoWhileStatement:
+          checkNode(node.body);
+          break;
+        case AST_NODE_TYPES.TryStatement:
+          checkNode(node.block);
+          if (node.handler) {
+            checkNode(node.handler.body);
+          }
+          if (node.finalizer) {
+            checkNode(node.finalizer);
+          }
+          break;
+        // Ignore nested functions
+        case AST_NODE_TYPES.FunctionExpression:
+        case AST_NODE_TYPES.ArrowFunctionExpression:
+        case AST_NODE_TYPES.FunctionDeclaration:
+          return;
+        default:
+          if ('body' in node && Array.isArray(node.body)) {
+            node.body.forEach(checkNode);
+          }
+          break;
+      }
+    }
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+      CallExpression(node): void {
+        const zodSchemaMeta = detectZodSchemaRootNode(node);
+
+        if (!zodSchemaMeta) {
+          return;
+        }
+
+        const refineMethod = collectZodChainMethods(node).find((it) => it.name === 'refine');
+
+        if (!refineMethod) {
+          return;
+        }
+
+        const [callback] = refineMethod.node.arguments;
+        if (
+          callback.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          callback.type === AST_NODE_TYPES.FunctionExpression
+        ) {
+          checkNode(callback.body);
+        }
+      },
+    };
+  };
+}

--- a/plugins/eslint-plugin-zod-mini/README.md
+++ b/plugins/eslint-plugin-zod-mini/README.md
@@ -40,6 +40,7 @@ Find out more about [Oxlint's `jsPLugins`](https://oxc.rs/docs/guide/usage/linte
 | [consistent-schema-var-name](docs/rules/consistent-schema-var-name.md)                   | Enforce a consistent naming convention for Zod Mini schema variables                               | ✅  |     |     |
 | [no-any-schema](docs/rules/no-any-schema.md)                                             | Disallow usage of `z.any()` in Zod Mini schemas                                                    | ✅  |     | 💡  |
 | [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                           | Disallow usage of `z.custom()` without arguments                                                   | ✅  |     |     |
+| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                                   | Disallow throwing errors directly inside Zod Mini refine callbacks                                 | ✅  |     |     |
 | [no-unknown-schema](docs/rules/no-unknown-schema.md)                                     | Disallow usage of `z.unknown()` in Zod Mini schemas                                                |     |     |     |
 | [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)           | Prefer `z.enum()` over `z.union()` when all members are string literals.                           | ✅  | 🔧  |     |
 | [prefer-meta](docs/rules/prefer-meta.md)                                                 | Enforce usage of `z.meta()` over `z.describe()`                                                    | ✅  | 🔧  |     |

--- a/plugins/eslint-plugin-zod-mini/docs/rules/no-throw-in-refine.md
+++ b/plugins/eslint-plugin-zod-mini/docs/rules/no-throw-in-refine.md
@@ -1,0 +1,63 @@
+# zod-mini/no-throw-in-refine
+
+📝 Disallow throwing errors directly inside Zod Mini refine callbacks.
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+## Rule details
+
+This ESLint rule detects and prevents `throw` statements directly inside Zod Mini `z.refine()` callbacks.
+It ignores throws in nested functions but ensures the call is a **Zod Mini expression**.
+
+From the [Refinements](https://zod.dev/api?id=refinements) documentation:
+
+> Refinement functions should never throw. Instead they should return a falsy value to signal failure.
+> Thrown errors are not caught by Zod.
+
+## Examples
+
+### ❌ Invalid
+
+```ts
+import * as z from 'zod/mini';
+
+z.number().check(
+  z.refine((val) => {
+    if (val < 0) {
+      throw new Error('Invalid');
+    }
+
+    return true;
+  }),
+);
+
+z.string().check(
+  z.refine(() => {
+    throw new Error('No');
+  }),
+);
+```
+
+### ✅ Valid
+
+```ts
+import * as z from 'zod/mini';
+
+z.number().check(z.refine((val) => val >= 0));
+
+z.string().check(
+  z.refine((val) => {
+    const fn = () => {
+      throw new Error('nested');
+    };
+
+    return val.length > 0;
+  }),
+);
+```
+
+## Further readings
+
+- [Zod - Refinements](https://zod.dev/api?id=refinements)

--- a/plugins/eslint-plugin-zod-mini/src/index.ts
+++ b/plugins/eslint-plugin-zod-mini/src/index.ts
@@ -8,6 +8,7 @@ import { consistentSchemaOutputTypeStyle } from './rules/consistent-schema-outpu
 import { consistentSchemaVarName } from './rules/consistent-schema-var-name.js';
 import { noAnySchema } from './rules/no-any-schema.js';
 import { noEmptyCustomSchema } from './rules/no-empty-custom-schema.js';
+import { noThrowInRefine } from './rules/no-throw-in-refine.js';
 import { noUnknownSchema } from './rules/no-unknown-schema.js';
 import { preferEnumOverLiteralUnion } from './rules/prefer-enum-over-literal-union.js';
 import { preferMeta } from './rules/prefer-meta.js';
@@ -41,6 +42,7 @@ const eslintPluginZodMini = {
     'consistent-schema-var-name': consistentSchemaVarName,
     'no-any-schema': noAnySchema,
     'no-empty-custom-schema': noEmptyCustomSchema,
+    'no-throw-in-refine': noThrowInRefine,
     'no-unknown-schema': noUnknownSchema,
     'prefer-enum-over-literal-union': preferEnumOverLiteralUnion,
     'prefer-meta': preferMeta,
@@ -65,6 +67,7 @@ const recommendedConfig = {
     'zod-mini/consistent-schema-var-name': 'error',
     'zod-mini/no-any-schema': 'error',
     'zod-mini/no-empty-custom-schema': 'error',
+    'zod-mini/no-throw-in-refine': 'error',
     'zod-mini/prefer-enum-over-literal-union': 'error',
     'zod-mini/prefer-meta': 'error',
     'zod-mini/require-brand-type-parameter': 'error',

--- a/plugins/eslint-plugin-zod-mini/src/rules/no-throw-in-refine.spec.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/no-throw-in-refine.spec.ts
@@ -1,0 +1,119 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { noThrowInRefine } from './no-throw-in-refine.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(noThrowInRefine.name, noThrowInRefine, {
+  valid: [
+    {
+      name: 'refine with arrow body shorthand',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.number().check(z.refine((val) => val >= 0));
+      `,
+    },
+    {
+      name: 'nested function not reported',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.string().check(z.refine((val) => {
+          const fn = () => {
+            throw new Error('nested');
+          };
+          return val.length > 0;
+        }));
+      `,
+    },
+    {
+      name: 'named imports',
+      code: dedent`
+        import { refine, string } from 'zod/mini';
+        string().check(refine((val) => val.length > 0));
+      `,
+    },
+    {
+      name: 'refine not starting with zod mini import',
+      code: dedent`
+        import * as z from 'zod';
+        z.number().refine(() => {
+          throw new Error('boom');
+        });
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'inside arrow function',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.string().check(z.refine(() => {
+          throw new Error();
+        }));
+      `,
+      errors: [{ messageId: 'noThrowInRefine' }],
+    },
+    {
+      name: 'inside arrow function (named)',
+      code: dedent`
+        import { refine, string } from 'zod/mini';
+        string().check(refine(() => {
+          throw new Error();
+        }));
+      `,
+      errors: [{ messageId: 'noThrowInRefine' }],
+    },
+    {
+      name: 'inside arrow function within if',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.number().check(z.refine((val) => {
+          if (val < 0) {
+            throw new Error('Invalid');
+          }
+          return true;
+        }));
+      `,
+      errors: [{ messageId: 'noThrowInRefine' }],
+    },
+    {
+      name: 'inside arrow function within else',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.number().check(z.refine((val) => {
+          if (val < 0) {
+            return true;
+          }
+
+          throw new Error('Invalid');
+        }));
+      `,
+      errors: [{ messageId: 'noThrowInRefine' }],
+    },
+    {
+      name: 'inside arrow function within cycle',
+      code: dedent`
+        import * as z from 'zod/mini';
+        z.number().check(z.refine((val) => {
+          for (const item of val) {
+            throw new Error('Invalid');
+          }
+
+          return true;
+        }));
+      `,
+      errors: [{ messageId: 'noThrowInRefine' }],
+    },
+    {
+      name: 'zod/v4-mini import',
+      code: dedent`
+        import * as z from 'zod/v4-mini';
+        z.string().check(z.refine(() => {
+          throw new Error('No');
+        }));
+      `,
+      errors: [{ messageId: 'noThrowInRefine' }],
+    },
+  ],
+});

--- a/plugins/eslint-plugin-zod-mini/src/rules/no-throw-in-refine.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/no-throw-in-refine.ts
@@ -1,0 +1,20 @@
+import { zodMiniImportScope } from '@eslint-zod/utils';
+import { buildNoThrowInRefineCreate } from '@eslint-zod/utils/rule-builders/no-throw-in-refine';
+
+import { createZodMiniPluginRule } from '../utils/create-plugin-rule.js';
+
+export const noThrowInRefine = createZodMiniPluginRule({
+  name: 'no-throw-in-refine',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow throwing errors directly inside Zod Mini refine callbacks',
+    },
+    messages: {
+      noThrowInRefine: 'Do not throw errors directly inside a z.refine callback.',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create: buildNoThrowInRefineCreate(zodMiniImportScope),
+});

--- a/plugins/eslint-plugin-zod/src/rules/no-throw-in-refine.ts
+++ b/plugins/eslint-plugin-zod/src/rules/no-throw-in-refine.ts
@@ -1,10 +1,7 @@
-import { createZodSchemaImportTrack, zodImportScope } from '@eslint-zod/utils';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import type { TSESTree } from '@typescript-eslint/utils';
+import { zodImportScope } from '@eslint-zod/utils';
+import { buildNoThrowInRefineCreate } from '@eslint-zod/utils/rule-builders/no-throw-in-refine';
 
 import { createZodPluginRule } from '../utils/create-plugin-rule.js';
-
-const { trackZodSchemaImports } = createZodSchemaImportTrack(zodImportScope);
 
 export const noThrowInRefine = createZodPluginRule({
   name: 'no-throw-in-refine',
@@ -19,82 +16,5 @@ export const noThrowInRefine = createZodPluginRule({
     schema: [],
   },
   defaultOptions: [],
-  create(context) {
-    const { importDeclarationListener, detectZodSchemaRootNode, collectZodChainMethods } =
-      trackZodSchemaImports();
-
-    function checkNode(node: TSESTree.Node | null): void {
-      if (!node) {
-        return;
-      }
-
-      switch (node.type) {
-        case AST_NODE_TYPES.ThrowStatement:
-          context.report({ node, messageId: 'noThrowInRefine' });
-          break;
-        case AST_NODE_TYPES.BlockStatement:
-          node.body.forEach(checkNode);
-          break;
-        case AST_NODE_TYPES.IfStatement:
-          checkNode(node.consequent);
-          if (node.alternate) {
-            checkNode(node.alternate);
-          }
-          break;
-        case AST_NODE_TYPES.ForStatement:
-        case AST_NODE_TYPES.ForInStatement:
-        case AST_NODE_TYPES.ForOfStatement:
-        case AST_NODE_TYPES.WhileStatement:
-        case AST_NODE_TYPES.DoWhileStatement:
-          checkNode(node.body);
-          break;
-        case AST_NODE_TYPES.TryStatement:
-          checkNode(node.block);
-          if (node.handler) {
-            checkNode(node.handler.body);
-          }
-          if (node.finalizer) {
-            checkNode(node.finalizer);
-          }
-          break;
-        // Ignore nested functions
-        case AST_NODE_TYPES.FunctionExpression:
-        case AST_NODE_TYPES.ArrowFunctionExpression:
-        case AST_NODE_TYPES.FunctionDeclaration:
-          return;
-        default:
-          if ('body' in node && Array.isArray(node.body)) {
-            node.body.forEach(checkNode);
-          }
-          break;
-      }
-    }
-
-    return {
-      ImportDeclaration: importDeclarationListener,
-      CallExpression(node): void {
-        const zodSchemaMeta = detectZodSchemaRootNode(node);
-
-        if (!zodSchemaMeta) {
-          return;
-        }
-
-        const methods = collectZodChainMethods(node);
-
-        const refineMethod = methods.find((it) => it.name === 'refine');
-
-        if (!refineMethod) {
-          return;
-        }
-
-        const [callback] = refineMethod.node.arguments;
-        if (
-          callback.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-          callback.type === AST_NODE_TYPES.FunctionExpression
-        ) {
-          checkNode(callback.body);
-        }
-      },
-    };
-  },
+  create: buildNoThrowInRefineCreate(zodImportScope),
 });


### PR DESCRIPTION
## Summary

- add `no-throw-in-refine` to `eslint-plugin-zod-mini`
- enable the rule in the mini plugin's `recommended` config
- extract the shared `create` logic into `@eslint-zod/utils/rule-builders/no-throw-in-refine`
- switch `eslint-plugin-zod` to use the shared builder so both plugins stay in sync
- add rule docs/tests for Zod Mini and regenerate the mini plugin README

## Why

Zod refine callbacks should return a falsy value to signal failure rather than throw. This ports that enforcement to Zod Mini and keeps the implementation aligned across both plugins by moving the rule logic into `@eslint-zod/utils`.

## Package impact

- `eslint-plugin-zod-mini`: new `no-throw-in-refine` rule
- `@eslint-zod/utils`: new `rule-builders/no-throw-in-refine` export for shared rule creation
- `eslint-plugin-zod`: internal refactor to consume the shared implementation with no intended behavior change
