### PR TITLE
feat(eslint-plugin-zod-mini): add `no-transform-in-record-key` rule

### DIFF
--- a/.changeset/fancy-garlics-rhyme.md
+++ b/.changeset/fancy-garlics-rhyme.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod-mini': minor
+---
+
+feat: add `no-transform-in-record-key` rule

--- a/plugins/eslint-plugin-zod-mini/README.md
+++ b/plugins/eslint-plugin-zod-mini/README.md
@@ -31,22 +31,23 @@ Find out more about [Oxlint's `jsPLugins`](https://oxc.rs/docs/guide/usage/linte
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
 💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
-| Name                                                                                     | Description                                                                                        | 💼  | 🔧  | 💡  |
-| :--------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
-| [consistent-import](docs/rules/consistent-import.md)                                     | Enforce a consistent import style for Zod Mini                                                     | ✅  | 🔧  |     |
-| [consistent-import-source](docs/rules/consistent-import-source.md)                       | Enforce consistent source from Zod Mini imports                                                    |     |     | 💡  |
-| [consistent-object-schema-type](docs/rules/consistent-object-schema-type.md)             | Enforce consistent usage of Zod Mini schema methods                                                |     |     | 💡  |
-| [consistent-schema-output-type-style](docs/rules/consistent-schema-output-type-style.md) | Enforce consistent use of z.infer or z.output for schema type inference                            |     | 🔧  |     |
-| [consistent-schema-var-name](docs/rules/consistent-schema-var-name.md)                   | Enforce a consistent naming convention for Zod Mini schema variables                               | ✅  |     |     |
-| [no-any-schema](docs/rules/no-any-schema.md)                                             | Disallow usage of `z.any()` in Zod Mini schemas                                                    | ✅  |     | 💡  |
-| [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                           | Disallow usage of `z.custom()` without arguments                                                   | ✅  |     |     |
-| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                                   | Disallow throwing errors directly inside Zod Mini refine callbacks                                 | ✅  |     |     |
-| [no-unknown-schema](docs/rules/no-unknown-schema.md)                                     | Disallow usage of `z.unknown()` in Zod Mini schemas                                                |     |     |     |
-| [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)           | Prefer `z.enum()` over `z.union()` when all members are string literals.                           | ✅  | 🔧  |     |
-| [prefer-meta](docs/rules/prefer-meta.md)                                                 | Enforce usage of `z.meta()` over `z.describe()`                                                    | ✅  | 🔧  |     |
-| [require-brand-type-parameter](docs/rules/require-brand-type-parameter.md)               | Require type parameter on `.brand()` functions                                                     | ✅  |     | 💡  |
-| [require-error-message](docs/rules/require-error-message.md)                             | Enforce that custom refinements include an error message                                           | ✅  | 🔧  |     |
-| [schema-error-property-style](docs/rules/schema-error-property-style.md)                 | Enforce consistent style for error messages in Zod Mini schema validation (using ESQuery patterns) |     |     |     |
+| Name                                                                                     | Description                                                                                                              | 💼  | 🔧  | 💡  |
+| :--------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------- | :-- | :-- | :-- |
+| [consistent-import](docs/rules/consistent-import.md)                                     | Enforce a consistent import style for Zod Mini                                                                           | ✅  | 🔧  |     |
+| [consistent-import-source](docs/rules/consistent-import-source.md)                       | Enforce consistent source from Zod Mini imports                                                                          |     |     | 💡  |
+| [consistent-object-schema-type](docs/rules/consistent-object-schema-type.md)             | Enforce consistent usage of Zod Mini schema methods                                                                      |     |     | 💡  |
+| [consistent-schema-output-type-style](docs/rules/consistent-schema-output-type-style.md) | Enforce consistent use of z.infer or z.output for schema type inference                                                  |     | 🔧  |     |
+| [consistent-schema-var-name](docs/rules/consistent-schema-var-name.md)                   | Enforce a consistent naming convention for Zod Mini schema variables                                                     | ✅  |     |     |
+| [no-any-schema](docs/rules/no-any-schema.md)                                             | Disallow usage of `z.any()` in Zod Mini schemas                                                                          | ✅  |     | 💡  |
+| [no-empty-custom-schema](docs/rules/no-empty-custom-schema.md)                           | Disallow usage of `z.custom()` without arguments                                                                         | ✅  |     |     |
+| [no-throw-in-refine](docs/rules/no-throw-in-refine.md)                                   | Disallow throwing errors directly inside Zod Mini refine callbacks                                                       | ✅  |     |     |
+| [no-transform-in-record-key](docs/rules/no-transform-in-record-key.md)                   | Disallow transforms in z.record() key schemas, which can cause silent key mutations and data loss through key collisions |     |     |     |
+| [no-unknown-schema](docs/rules/no-unknown-schema.md)                                     | Disallow usage of `z.unknown()` in Zod Mini schemas                                                                      |     |     |     |
+| [prefer-enum-over-literal-union](docs/rules/prefer-enum-over-literal-union.md)           | Prefer `z.enum()` over `z.union()` when all members are string literals.                                                 | ✅  | 🔧  |     |
+| [prefer-meta](docs/rules/prefer-meta.md)                                                 | Enforce usage of `z.meta()` over `z.describe()`                                                                          | ✅  | 🔧  |     |
+| [require-brand-type-parameter](docs/rules/require-brand-type-parameter.md)               | Require type parameter on `.brand()` functions                                                                           | ✅  |     | 💡  |
+| [require-error-message](docs/rules/require-error-message.md)                             | Enforce that custom refinements include an error message                                                                 | ✅  | 🔧  |     |
+| [schema-error-property-style](docs/rules/schema-error-property-style.md)                 | Enforce consistent style for error messages in Zod Mini schema validation (using ESQuery patterns)                       |     |     |     |
 
 <!-- end auto-generated rules list -->
 

--- a/plugins/eslint-plugin-zod-mini/docs/rules/no-transform-in-record-key.md
+++ b/plugins/eslint-plugin-zod-mini/docs/rules/no-transform-in-record-key.md
@@ -1,0 +1,86 @@
+# zod-mini/no-transform-in-record-key
+
+📝 Disallow transforms in z.record() key schemas, which can cause silent key mutations and data loss through key collisions.
+
+<!-- end auto-generated rule header -->
+
+## Rule Details
+
+This ESLint rule detects mutating checks in `z.record()` key schemas and prevents them.
+
+In Zod Mini, transforms are standalone `$ZodCheck` functions passed into `.check()`. Using mutating checks like `z.trim()`, `z.toLowerCase()`, `z.toUpperCase()`, `z.normalize()`, or `z.overwrite()` on the key schema in `z.record()` causes silent key mutation and data loss through key collisions.
+
+### The Problem
+
+When you use `z.record(z.string().check(z.trim()), z.unknown())`, Zod Mini applies the `z.trim()` mutation to every object key during parsing. This creates two critical issues:
+
+1. **Silent key mutation** — Keys are transformed without the developer realizing it, since `z.record()` looks like a validation boundary.
+
+2. **Key collision and data loss** — Two distinct input keys can collapse into one after the transform:
+
+   ```ts
+   import * as z from 'zod/mini';
+
+   const schema = z.record(z.string().check(z.trim()), z.unknown());
+   const input = { ' id ': 'abc-123', id: 'def-456', '  source': 'google' };
+   const result = schema.parse(input);
+   // Result: { id: "def-456", source: "google" }
+   // " id " -> "id" (collides with existing "id"), "abc-123" is silently lost!
+   // "  source" -> "source" (mutated key)
+   ```
+
+This is especially dangerous when the record is forwarded to a backend API or analytics pipeline. The receiving system sees different keys than intended.
+
+## Why?
+
+Most developers reaching for `z.record(z.string().check(z.trim()), z.unknown())` intend to validate that keys are strings, not mutate them. Mutating checks inside record keys turn a validation boundary into an implicit rewrite step.
+
+## Examples
+
+### ❌ Invalid
+
+```ts
+import * as z from 'zod/mini';
+
+// z.trim() silently rewrites keys
+const config = z.record(z.string().check(z.trim()), z.unknown());
+
+// z.toLowerCase() can collapse distinct keys into one
+const userMap = z.record(z.string().check(z.toLowerCase()), z.unknown());
+
+// z.normalize() also mutates keys
+const aliases = z.record(z.string().check(z.normalize()), z.string());
+
+// z.overwrite() is a mutating check too
+const configWithOverwrite = z.record(
+  z.string().check(z.overwrite((value) => value.trim())),
+  z.unknown(),
+);
+```
+
+### ✅ Valid
+
+```ts
+import * as z from 'zod/mini';
+
+// Plain string key
+const config = z.record(z.string(), z.unknown());
+
+// Validation-only checks are fine
+const validatedKeys = z.record(z.string().check(z.minLength(1)), z.unknown());
+
+// lowercase() validates; it does not mutate the key
+const lowercaseKeys = z.record(z.string().check(z.lowercase()), z.number());
+
+// Transform on the value schema is fine
+const trimmedValues = z.record(z.string(), z.string().check(z.trim()));
+```
+
+## When Not To Use It
+
+This rule should usually stay enabled. If you need to normalize external keys, do that before schema parsing or in a dedicated normalization step after validating the input shape.
+
+## Further Reading
+
+- [Zod - Records](https://zod.dev/api?id=records)
+- [Zod Mini](https://zod.dev/packages/mini)

--- a/plugins/eslint-plugin-zod-mini/src/index.ts
+++ b/plugins/eslint-plugin-zod-mini/src/index.ts
@@ -9,6 +9,7 @@ import { consistentSchemaVarName } from './rules/consistent-schema-var-name.js';
 import { noAnySchema } from './rules/no-any-schema.js';
 import { noEmptyCustomSchema } from './rules/no-empty-custom-schema.js';
 import { noThrowInRefine } from './rules/no-throw-in-refine.js';
+import { noTransformInRecordKey } from './rules/no-transform-in-record-key.js';
 import { noUnknownSchema } from './rules/no-unknown-schema.js';
 import { preferEnumOverLiteralUnion } from './rules/prefer-enum-over-literal-union.js';
 import { preferMeta } from './rules/prefer-meta.js';
@@ -43,6 +44,7 @@ const eslintPluginZodMini = {
     'no-any-schema': noAnySchema,
     'no-empty-custom-schema': noEmptyCustomSchema,
     'no-throw-in-refine': noThrowInRefine,
+    'no-transform-in-record-key': noTransformInRecordKey,
     'no-unknown-schema': noUnknownSchema,
     'prefer-enum-over-literal-union': preferEnumOverLiteralUnion,
     'prefer-meta': preferMeta,

--- a/plugins/eslint-plugin-zod-mini/src/rules/no-transform-in-record-key.spec.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/no-transform-in-record-key.spec.ts
@@ -1,0 +1,191 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import dedent from 'dedent';
+
+import { noTransformInRecordKey } from './no-transform-in-record-key.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run(noTransformInRecordKey.name, noTransformInRecordKey, {
+  valid: [
+    {
+      name: 'plain string key without transforms',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string(), z.unknown());
+      `,
+    },
+    {
+      name: 'string key with validators',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.minLength(1), z.maxLength(100)), z.unknown());
+      `,
+    },
+    {
+      name: 'enum key without transforms',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.enum(['a', 'b', 'c']), z.number());
+      `,
+    },
+    {
+      name: 'lowercase validator does not mutate keys',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.lowercase()), z.unknown());
+      `,
+    },
+    {
+      name: 'transform on value schema is fine',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string(), z.string().check(z.trim()));
+      `,
+    },
+    {
+      name: 'named import without transforms',
+      code: dedent`
+        import { record, string, unknown } from 'zod/mini';
+        const config = record(string(), unknown());
+      `,
+    },
+    {
+      name: 'named import with validators',
+      code: dedent`
+        import { maxLength, minLength, record, string, unknown } from 'zod/mini';
+        const config = record(string().check(minLength(1), maxLength(100)), unknown());
+      `,
+    },
+    {
+      name: 'named import lowercase validator',
+      code: dedent`
+        import { lowercase, record, string, unknown } from 'zod/mini';
+        const config = record(string().check(lowercase()), unknown());
+      `,
+    },
+    {
+      name: 'named z import',
+      code: dedent`
+        import { z } from 'zod/mini';
+        const config = z.record(z.string().check(z.minLength(1)), z.unknown());
+      `,
+    },
+    {
+      name: 'zod/v4-mini import',
+      code: dedent`
+        import * as z from 'zod/v4-mini';
+        const config = z.record(z.string().check(z.minLength(1)), z.unknown());
+      `,
+    },
+    {
+      name: 'not triggered on zod import',
+      code: dedent`
+        import * as z from 'zod';
+        const config = z.record(z.string().trim(), z.unknown());
+      `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'trim on key schema',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.trim()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'toLowerCase on key schema',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.toLowerCase()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'toUpperCase on key schema',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.toUpperCase()), z.number());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'normalize on key schema',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.normalize()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'overwrite on key schema',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(
+          z.string().check(z.overwrite((value) => value.trim())),
+          z.unknown(),
+        );
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'transform after validators on key schema',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.minLength(1), z.trim()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'chained check calls with trim',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const config = z.record(z.string().check(z.minLength(1)).check(z.trim()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'named import with trim',
+      code: dedent`
+        import { record, string, trim, unknown } from 'zod/mini';
+        const config = record(string().check(trim()), unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'named import with toLowerCase',
+      code: dedent`
+        import { record, string, toLowerCase, unknown } from 'zod/mini';
+        const config = record(string().check(toLowerCase()), unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'named z import with toUpperCase',
+      code: dedent`
+        import { z } from 'zod/mini';
+        const config = z.record(z.string().check(z.minLength(1), z.toUpperCase()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'zod/v4-mini import',
+      code: dedent`
+        import * as z from 'zod/v4-mini';
+        const config = z.record(z.string().check(z.trim()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'real-world example with data loss',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const schema = z.record(z.string().check(z.trim()), z.unknown());
+        const input = { " id ": "abc-123", id: "def-456" };
+        const result = schema.parse(input);
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+  ],
+});

--- a/plugins/eslint-plugin-zod-mini/src/rules/no-transform-in-record-key.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/no-transform-in-record-key.ts
@@ -1,0 +1,94 @@
+import { createZodSchemaImportTrack, zodMiniImportScope } from '@eslint-zod/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
+
+import { createZodMiniPluginRule } from '../utils/create-plugin-rule.js';
+
+const { trackZodSchemaImports } = createZodSchemaImportTrack(zodMiniImportScope);
+
+/**
+ * Methods that mutate/transform the value and should not be used in z.record() key schemas
+ */
+const TRANSFORM_CHECKS = new Set(['normalize', 'overwrite', 'toLowerCase', 'toUpperCase', 'trim']);
+
+export const noTransformInRecordKey = createZodMiniPluginRule({
+  name: 'no-transform-in-record-key',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow transforms in z.record() key schemas, which can cause silent key mutations and data loss through key collisions',
+    },
+    messages: {
+      noTransformInRecordKey:
+        'Transforms in z.record() key schemas cause silent key mutation and potential data loss. Use validators like z.minLength() instead of mutating checks like z.trim() or z.toLowerCase().',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    const { importDeclarationListener, detectZodSchemaRootNode, collectZodChainMethods } =
+      trackZodSchemaImports();
+
+    // In Zod Mini, key mutations are passed as standalone checks into .check(...),
+    // so scan each check argument and return the first mutating one we find.
+    function getTransformCheck(
+      schema: TSESTree.Expression | TSESTree.SpreadElement,
+    ): TSESTree.CallExpression | null {
+      if (schema.type !== AST_NODE_TYPES.CallExpression) {
+        return null;
+      }
+
+      for (const method of collectZodChainMethods(schema)) {
+        if (method.name !== 'check') {
+          continue;
+        }
+
+        for (const argument of method.node.arguments) {
+          if (argument.type !== AST_NODE_TYPES.CallExpression) {
+            continue;
+          }
+
+          const zodCheck = detectZodSchemaRootNode(argument);
+
+          if (zodCheck && TRANSFORM_CHECKS.has(zodCheck.schemaType)) {
+            return argument;
+          }
+        }
+      }
+
+      return null;
+    }
+
+    return {
+      ImportDeclaration: importDeclarationListener,
+      CallExpression(node): void {
+        const zodSchemaMeta = detectZodSchemaRootNode(node);
+
+        // Only care about z.record() calls
+        if (zodSchemaMeta?.schemaType !== 'record') {
+          return;
+        }
+
+        // Get the first argument, which is the key schema
+        const keySchemaArg = node.arguments.at(0);
+
+        // Skip if there's no key schema
+        if (!keySchemaArg) {
+          return;
+        }
+
+        const transformCheck = getTransformCheck(keySchemaArg);
+
+        if (!transformCheck) {
+          return;
+        }
+
+        context.report({
+          node: transformCheck,
+          messageId: 'noTransformInRecordKey',
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Summary

This PR adds a new `eslint-plugin-zod-mini rule`, `no-transform-in-record-key`, to prevent mutating checks inside `z.record()` key schemas.

Mutating key checks such as `z.trim()`, `z.toLowerCase()`, `z.toUpperCase()`, `z.normalize()`, and `z.overwrite()` can silently rewrite object keys during parsing. That can cause distinct input keys to collapse into the same output key, which introduces unexpected behaviour and potential data loss.

## What Changed

- Added the new `no-transform-in-record-key` rule to eslint-plugin-zod-mini
- Registered the rule in the plugin export
- Added rule documentation and updated the plugin README rule list
- Added focused rule tests covering valid and invalid cases
- Added a changeset for a minor release

## Why

Using mutating checks in record keys turns schema validation into an implicit normalization step. In practice, that means inputs like `" id "` and `"id"` can end up as the same parsed key, with one value silently overwriting the other. This rule makes that failure mode explicit at lint time.