### PR TITLE
fix(eslint-plugin-zod): `no-transform-in-record-key` - add `normalize` and `overwrite` methods

### DIFF
--- a/.changeset/wicked-kings-jam.md
+++ b/.changeset/wicked-kings-jam.md
@@ -1,5 +1,5 @@
 ---
-'eslint-plugin-zod': minor
+'eslint-plugin-zod': patch
 ---
 
-flag `normalize` and `overwrite` in record keys for `no-transform-in-record-key` rule
+fix(no-transform-in-record-key): add `normalize` and `overwrite` methods

--- a/.changeset/wicked-kings-jam.md
+++ b/.changeset/wicked-kings-jam.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-zod': minor
+---
+
+flag `normalize` and `overwrite` in record keys for `no-transform-in-record-key` rule

--- a/plugins/eslint-plugin-zod/docs/rules/no-transform-in-record-key.md
+++ b/plugins/eslint-plugin-zod/docs/rules/no-transform-in-record-key.md
@@ -8,7 +8,7 @@
 
 This ESLint rule detects **transforms in `z.record()` key schemas** and prevents them.
 
-Using transforms (like `.trim()`, `.toLowerCase()`, `.toUpperCase()`, or `.transform()`) on the key schema in `z.record()` causes silent key mutation and data loss through key collisions.
+Using transforms (like `.trim()`, `.normalize()`, `.toLowerCase()`, `.toUpperCase()`, `.overwrite()`, or `.transform()`) on the key schema in `z.record()` causes silent key mutation and data loss through key collisions.
 
 ### The Problem
 
@@ -51,6 +51,15 @@ const config = z.record(z.string().toUpperCase(), z.number());
 // Chained transforms on the key
 const config = z.record(z.string().trim().toLowerCase(), z.unknown());
 
+// .normalize() mutates the parsed key value
+const config = z.record(z.string().normalize(), z.unknown());
+
+// .overwrite() still rewrites the parsed key, even if the inferred type stays the same
+const config = z.record(
+  z.string().overwrite((value) => value.trim()),
+  z.unknown(),
+);
+
 // .transform() is never allowed on keys
 const config = z.record(
   z.string().transform((v) => v.trim()),
@@ -72,6 +81,13 @@ const config = z.record(z.enum(['a', 'b', 'c']), z.number());
 
 // Transform on the *value* schema is fine — values aren't used as keys
 const config = z.record(z.string(), z.string().trim());
+
+// Same for normalize()/overwrite() on values
+const config = z.record(z.string(), z.string().normalize());
+const config = z.record(
+  z.string(),
+  z.string().overwrite((value) => value.trim()),
+);
 ```
 
 ## When Not To Use It

--- a/plugins/eslint-plugin-zod/src/rules/no-transform-in-record-key.spec.ts
+++ b/plugins/eslint-plugin-zod/src/rules/no-transform-in-record-key.spec.ts
@@ -57,6 +57,20 @@ ruleTester.run(noTransformInRecordKey.name, noTransformInRecordKey, {
       `,
     },
     {
+      name: 'normalize on value schema (not key) is fine',
+      code: dedent`
+        import * as z from 'zod';
+        const config = z.record(z.string(), z.string().normalize());
+      `,
+    },
+    {
+      name: 'overwrite on value schema (not key) is fine',
+      code: dedent`
+        import * as z from 'zod';
+        const config = z.record(z.string(), z.string().overwrite((value) => value.trim()));
+      `,
+    },
+    {
       name: 'not zod.record',
       code: 'const config = someOtherLib.record(z.string().trim(), z.unknown());',
     },
@@ -145,6 +159,22 @@ ruleTester.run(noTransformInRecordKey.name, noTransformInRecordKey, {
       errors: [{ messageId: 'noTransformInRecordKey' }],
     },
     {
+      name: 'normalize on key schema',
+      code: dedent`
+        import * as z from 'zod';
+        const config = z.record(z.string().normalize(), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'overwrite on key schema',
+      code: dedent`
+        import * as z from 'zod';
+        const config = z.record(z.string().overwrite((value) => value.trim()), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
       name: 'chained transforms on key schema',
       code: dedent`
         import * as z from 'zod';
@@ -201,6 +231,14 @@ ruleTester.run(noTransformInRecordKey.name, noTransformInRecordKey, {
       errors: [{ messageId: 'noTransformInRecordKey' }],
     },
     {
+      name: 'named import with normalize',
+      code: dedent`
+        import { record, string } from 'zod';
+        const config = record(string().normalize(), string());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
       name: 'named z import with trim',
       code: dedent`
         import { z } from 'zod';
@@ -221,6 +259,14 @@ ruleTester.run(noTransformInRecordKey.name, noTransformInRecordKey, {
       code: dedent`
         import { z } from 'zod';
         const config = z.record(z.string().trim().toUpperCase(), z.unknown());
+      `,
+      errors: [{ messageId: 'noTransformInRecordKey' }],
+    },
+    {
+      name: 'named z import with overwrite',
+      code: dedent`
+        import { z } from 'zod';
+        const config = z.record(z.string().overwrite((value) => value.trim()), z.unknown());
       `,
       errors: [{ messageId: 'noTransformInRecordKey' }],
     },

--- a/plugins/eslint-plugin-zod/src/rules/no-transform-in-record-key.ts
+++ b/plugins/eslint-plugin-zod/src/rules/no-transform-in-record-key.ts
@@ -9,7 +9,15 @@ const { trackZodSchemaImports } = createZodSchemaImportTrack(zodImportScope);
 /**
  * Methods that mutate/transform the value and should not be used in z.record() key schemas
  */
-const TRANSFORM_METHODS = ['transform', 'map', 'trim', 'toLowerCase', 'toUpperCase'];
+const TRANSFORM_METHODS = [
+  'transform',
+  'map',
+  'trim',
+  'toLowerCase',
+  'toUpperCase',
+  'normalize',
+  'overwrite',
+];
 
 export const noTransformInRecordKey = createZodPluginRule({
   name: 'no-transform-in-record-key',


### PR DESCRIPTION
## Summary

Extend `no-transform-in-record-key` so it also reports `normalize()` and
`overwrite()` when they are used in `z.record()` key schemas.

## Changes

- add `normalize` and `overwrite` to the rule's disallowed key-mutating methods
- add test coverage for both methods across namespace, named, and `z` imports
- update the rule docs with invalid key examples and valid value-schema examples