### PR TITLE
fix(consistent-schema-var-name): refine prefix/suffix handling

### DIFF
--- a/.changeset/quick-foxes-hop.md
+++ b/.changeset/quick-foxes-hop.md
@@ -1,0 +1,9 @@
+---
+'eslint-plugin-zod': patch
+'eslint-plugin-zod-mini': patch
+'@eslint-zod/utils': patch
+---
+
+fix(consistent-schema-var-name): refine prefix/suffix handling
+
+accept a bare token matching either affix case-insensitively when only one side is configured, and use the configured affix casing in rename suggestions

--- a/packages/utils/src/rule-builders/consistent-schema-var-name.ts
+++ b/packages/utils/src/rule-builders/consistent-schema-var-name.ts
@@ -54,14 +54,17 @@ export function buildConsistentSchemaVarNameCreate(
           return;
         }
 
-        const validPrefix = !before || name.startsWith(before) || matchesBarePrefix;
-        const validSuffix = !after || name.endsWith(after) || matchesBareSuffix;
+        const validPrefix = !before || name.startsWith(before);
+        const validSuffix = !after || name.endsWith(after);
 
         if (validPrefix && validSuffix) {
           return;
         }
 
-        const expected = (validPrefix ? '' : before) + name + (validSuffix ? '' : after);
+        const expected =
+          matchesBarePrefix || matchesBareSuffix
+            ? before + after
+            : (validPrefix ? '' : before) + name + (validSuffix ? '' : after);
 
         context.report({
           node,

--- a/packages/utils/src/rule-builders/consistent-schema-var-name.ts
+++ b/packages/utils/src/rule-builders/consistent-schema-var-name.ts
@@ -45,8 +45,17 @@ export function buildConsistentSchemaVarNameCreate(
         }
 
         const { name } = node.id;
-        const validPrefix = !before || name.startsWith(before);
-        const validSuffix = !after || name.endsWith(after);
+
+        const nameLower = name.toLowerCase();
+        const matchesBarePrefix = Boolean(before) && nameLower === before.toLowerCase();
+        const matchesBareSuffix = Boolean(after) && nameLower === after.toLowerCase();
+
+        if ((!before && matchesBareSuffix) || (!after && matchesBarePrefix)) {
+          return;
+        }
+
+        const validPrefix = !before || name.startsWith(before) || matchesBarePrefix;
+        const validSuffix = !after || name.endsWith(after) || matchesBareSuffix;
 
         if (validPrefix && validSuffix) {
           return;

--- a/plugins/eslint-plugin-zod-mini/docs/rules/consistent-schema-var-name.md
+++ b/plugins/eslint-plugin-zod-mini/docs/rules/consistent-schema-var-name.md
@@ -11,6 +11,8 @@
 This rule enforces a consistent naming convention for Zod Mini schema variables by requiring them to start with a specified prefix and/or end with a specified suffix.
 The default behavior (suffix `'Schema'`) is equivalent to the deprecated `zod-mini/require-schema-suffix` rule.
 
+If only `before` or `after` is configured, a variable name equal to that token is also allowed, ignoring case.
+
 The rule ignores:
 
 - Variables that store parsed values (e.g., `.parse()`, `.safeParse()`)
@@ -82,6 +84,7 @@ const address = z.object({ street: z.string() });
 ```ts
 import * as z from 'zod/mini';
 
+const schema = z.string();
 const userSchema = z.string();
 const addressSchema = z.object({ street: z.string() });
 

--- a/plugins/eslint-plugin-zod-mini/src/rules/consistent-schema-var-name.spec.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/consistent-schema-var-name.spec.ts
@@ -21,7 +21,7 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const schema = z.string();
         const Schema = z.string();
         const SCHEMA = z.string();
-      `
+      `,
     },
     {
       name: 'named import',

--- a/plugins/eslint-plugin-zod-mini/src/rules/consistent-schema-var-name.spec.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/consistent-schema-var-name.spec.ts
@@ -147,7 +147,7 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const schema = z.string();
       `,
       options: [{ before: '$', after: 'Schema' }],
-      errors: [{ messageId: 'invalidName', data: { expected: '$schema' } }],
+      errors: [{ messageId: 'invalidName', data: { expected: '$Schema' } }],
       output: null,
     },
     {
@@ -157,7 +157,7 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const foo = z.string();
       `,
       options: [{ before: 'Foo', after: 'Schema' }],
-      errors: [{ messageId: 'invalidName', data: { expected: 'fooSchema' } }],
+      errors: [{ messageId: 'invalidName', data: { expected: 'FooSchema' } }],
       output: null,
     },
     {

--- a/plugins/eslint-plugin-zod-mini/src/rules/consistent-schema-var-name.spec.ts
+++ b/plugins/eslint-plugin-zod-mini/src/rules/consistent-schema-var-name.spec.ts
@@ -15,6 +15,15 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
       `,
     },
     {
+      name: 'valid suffix only (default suffix)',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const schema = z.string();
+        const Schema = z.string();
+        const SCHEMA = z.string();
+      `
+    },
+    {
       name: 'named import',
       code: dedent`
         import { string } from 'zod/mini';
@@ -58,12 +67,32 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
       options: [{ after: 'Var' }],
     },
     {
+      name: 'custom suffix bare token (case-insensitive)',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const bar = z.string();
+        const Bar = z.string();
+        const BAR = z.string();
+      `,
+      options: [{ after: 'Bar' }],
+    },
+    {
       name: 'prefix only',
       code: dedent`
         import * as z from 'zod/mini';
         const $user = z.string();
       `,
       options: [{ before: '$', after: '' }],
+    },
+    {
+      name: 'prefix only (case-insensitive)',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const foo = z.string();
+        const Foo = z.string();
+        const FOO = z.string();
+      `,
+      options: [{ before: 'foo', after: '' }],
     },
     {
       name: 'both prefix and suffix',
@@ -109,6 +138,26 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
       `,
       options: [{ before: '$', after: '' }],
       errors: [{ messageId: 'invalidName', data: { expected: '$user' } }],
+      output: null,
+    },
+    {
+      name: 'missing prefix with default suffix',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const schema = z.string();
+      `,
+      options: [{ before: '$', after: 'Schema' }],
+      errors: [{ messageId: 'invalidName', data: { expected: '$schema' } }],
+      output: null,
+    },
+    {
+      name: 'missing suffix with bare prefix token',
+      code: dedent`
+        import * as z from 'zod/mini';
+        const foo = z.string();
+      `,
+      options: [{ before: 'Foo', after: 'Schema' }],
+      errors: [{ messageId: 'invalidName', data: { expected: 'fooSchema' } }],
       output: null,
     },
     {

--- a/plugins/eslint-plugin-zod/docs/rules/consistent-schema-var-name.md
+++ b/plugins/eslint-plugin-zod/docs/rules/consistent-schema-var-name.md
@@ -11,6 +11,8 @@
 This rule enforces a consistent naming convention for Zod schema variables by requiring them to start with a specified prefix and/or end with a specified suffix.
 The default behavior (suffix `'Schema'`) is equivalent to the deprecated `zod/require-schema-suffix` rule.
 
+If only `before` or `after` is configured, a variable name equal to that token is also allowed, ignoring case.
+
 The rule ignores:
 
 - Variables that store parsed values (e.g., `.parse()`, `.safeParse()`)
@@ -79,6 +81,7 @@ const address = z.object({ street: z.string() });
 ✅ Valid
 
 ```ts
+const schema = z.string();
 const userSchema = z.string();
 const addressSchema = z.object({ street: z.string() });
 

--- a/plugins/eslint-plugin-zod/src/rules/consistent-schema-var-name.spec.ts
+++ b/plugins/eslint-plugin-zod/src/rules/consistent-schema-var-name.spec.ts
@@ -15,6 +15,15 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
       `,
     },
     {
+      name: 'valid suffix only (default suffix)',
+      code: dedent`
+        import * as z from 'zod';
+        const schema = z.string();
+        const Schema = z.string();
+        const SCHEMA = z.string();
+      `
+    },
+    {
       name: 'valid usage with multiple declarations',
       code: dedent`
         import * as z from 'zod';
@@ -42,6 +51,16 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const myVar = z.string()
       `,
       options: [{ after: 'Var' }],
+    },
+    {
+      name: 'custom suffix bare token (case-insensitive)',
+      code: dedent`
+        import * as z from 'zod';
+        const bar = z.string();
+        const Bar = z.string();
+        const BAR = z.string();
+      `,
+      options: [{ after: 'Bar' }],
     },
     {
       name: 'ignores non-zod',
@@ -151,6 +170,16 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const $user = z.string();
       `,
       options: [{ before: '$', after: '' }],
+    },
+    {
+      name: 'valid prefix only (case-insensitive)',
+      code: dedent`
+        import * as z from 'zod';
+        const foo = z.string();
+        const Foo = z.string();
+        const FOO = z.string();
+      `,
+      options: [{ before: 'foo', after: '' }],
     },
     {
       name: 'valid with both before and after',
@@ -291,6 +320,26 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
           data: { expected: '$user' },
         },
       ],
+      output: null,
+    },
+    {
+      name: 'missing prefix with default suffix',
+      code: dedent`
+        import * as z from 'zod';
+        const schema = z.string();
+      `,
+      options: [{ before: '$', after: 'Schema' }],
+      errors: [{ messageId: 'invalidName', data: { expected: '$schema' } }],
+      output: null,
+    },
+    {
+      name: 'missing suffix with bare prefix token',
+      code: dedent`
+        import * as z from 'zod';
+        const foo = z.string();
+      `,
+      options: [{ before: 'Foo', after: 'Schema' }],
+      errors: [{ messageId: 'invalidName', data: { expected: 'fooSchema' } }],
       output: null,
     },
     {

--- a/plugins/eslint-plugin-zod/src/rules/consistent-schema-var-name.spec.ts
+++ b/plugins/eslint-plugin-zod/src/rules/consistent-schema-var-name.spec.ts
@@ -21,7 +21,7 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const schema = z.string();
         const Schema = z.string();
         const SCHEMA = z.string();
-      `
+      `,
     },
     {
       name: 'valid usage with multiple declarations',

--- a/plugins/eslint-plugin-zod/src/rules/consistent-schema-var-name.spec.ts
+++ b/plugins/eslint-plugin-zod/src/rules/consistent-schema-var-name.spec.ts
@@ -329,7 +329,7 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const schema = z.string();
       `,
       options: [{ before: '$', after: 'Schema' }],
-      errors: [{ messageId: 'invalidName', data: { expected: '$schema' } }],
+      errors: [{ messageId: 'invalidName', data: { expected: '$Schema' } }],
       output: null,
     },
     {
@@ -339,7 +339,7 @@ ruleTester.run(consistentSchemaVarName.name, consistentSchemaVarName, {
         const foo = z.string();
       `,
       options: [{ before: 'Foo', after: 'Schema' }],
-      errors: [{ messageId: 'invalidName', data: { expected: 'fooSchema' } }],
+      errors: [{ messageId: 'invalidName', data: { expected: 'FooSchema' } }],
       output: null,
     },
     {


### PR DESCRIPTION
## Summary

Update `consistent-schema-var-name` to allow case-insensitive bare prefix/suffix token matches when only one side is configured.

Examples:
- `{ after: 'Schema' }` now accepts `schema`, `Schema`, and `SCHEMA`
- `{ before: 'foo', after: '' }` now accepts `foo`, `Foo`, and `FOO`

This also fixes the reported rename target when a bare token already satisfies one side of a two-sided config:
- `{ before: '$', after: 'Schema' }` now reports `schema` as `$schema` instead of `$schemaSchema`
- `{ before: 'Foo', after: 'Schema' }` now reports `foo` as `fooSchema`

## Tests

Added positive and negative cases for both `eslint-plugin-zod` and `eslint-plugin-zod-mini`. All tests passed.

Closes #324