### PR TITLE
fix(eslint-plugin-zod): no-duplicate-schema-methods - allow nested array schema chains

### DIFF
--- a/.changeset/soft-arrays-nest.md
+++ b/.changeset/soft-arrays-nest.md
@@ -2,6 +2,6 @@
 'eslint-plugin-zod': patch
 ---
 
-fix: allow chained array methods in no-duplicate-schema-methods
+fix(no-duplicate-schema-methods): allow chaining of array methods
 
-The `no-duplicate-schema-methods` rule now treats repeated `.array()` calls as valid nested array schema construction.
+Repeated `.array()` calls are now recognized as valid nested array schemas instead of being flagged as duplicate schema method usage.

--- a/.changeset/soft-arrays-nest.md
+++ b/.changeset/soft-arrays-nest.md
@@ -1,0 +1,7 @@
+---
+'eslint-plugin-zod': patch
+---
+
+fix: allow chained array methods in no-duplicate-schema-methods
+
+The `no-duplicate-schema-methods` rule now treats repeated `.array()` calls as valid nested array schema construction.

--- a/plugins/eslint-plugin-zod/docs/rules/no-duplicate-schema-methods.md
+++ b/plugins/eslint-plugin-zod/docs/rules/no-duplicate-schema-methods.md
@@ -10,7 +10,7 @@
 
 This rule disallows calling the same Zod schema method more than once within a single method chain. Duplicate calls are almost always a mistake — they are either redundant (e.g. calling `.trim()` twice) or create conflicting constraints (e.g. setting `.min()` twice with different values).
 
-Methods that are designed to be chained multiple times, such as `.or()` and `.and()`, are excluded from this check.
+Methods that are designed to be chained multiple times, such as `.or()`, `.and()`, and `.array()`, are excluded from this check.
 
 ## Examples
 
@@ -40,6 +40,9 @@ const bSchema = z.string().min(1).max(10);
 
 // .or() and .and() are excluded — chaining them is intentional
 const cSchema = z.string().or(z.number()).or(z.boolean());
+
+// .array() can be chained to create nested arrays
+const dSchema = z.string().nonempty().array().array();
 ```
 
 ## When Not To Use It

--- a/plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.spec.ts
+++ b/plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.spec.ts
@@ -78,6 +78,13 @@ ruleTester.run(noDuplicateSchemaMethods.name, noDuplicateSchemaMethods, {
       `,
     },
     {
+      name: 'namespace - array called multiple times for nested arrays (excluded)',
+      code: dedent`
+        import * as z from 'zod';
+        z.string().nonempty().array().array();
+      `,
+    },
+    {
       name: 'namespace - register called multiple times (excluded)',
       code: dedent`
         import * as z from 'zod';

--- a/plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.ts
+++ b/plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.ts
@@ -8,6 +8,7 @@ import { createZodPluginRule } from '../utils/create-plugin-rule.js';
  * called more than once in a single schema chain in the `zod` (full) API.
  *
  * - `and` / `or` — each call adds an intersection / union branch
+ * - `array` — each call wraps the previous schema in another array layer
  * - `check` — each call registers additional `$ZodCheck` validators
  * - `pipe` — each call pipes the output through another schema
  * - `refine` / `superRefine` — each call adds an independent refinement
@@ -16,6 +17,7 @@ import { createZodPluginRule } from '../utils/create-plugin-rule.js';
  */
 const EXCLUDED_METHODS = [
   'and',
+  'array',
   'check',
   'or',
   'pipe',


### PR DESCRIPTION
## Summary
- exclude `.array()` from duplicate method reporting for the full `zod/no-duplicate-schema-methods` rule
- add regression coverage for `z.string().nonempty().array().array()`
- document that repeated `.array()` calls are valid nested array schema construction
- add a patch changeset for `eslint-plugin-zod`

## Root cause
The rule treated every repeated chain method as a duplicate unless it was explicitly excluded. In Zod's full chained API, repeated `.array()` calls are meaningful because each call wraps the previous schema in another array layer.

Fixes #344.

## Checks
- `pnpm vitest run plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.spec.ts`
- `pnpm exec eslint plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.ts plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.spec.ts`
- `pnpm exec prettier --check plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.ts plugins/eslint-plugin-zod/src/rules/no-duplicate-schema-methods.spec.ts plugins/eslint-plugin-zod/docs/rules/no-duplicate-schema-methods.md .changeset/soft-arrays-nest.md`
- `pnpm --filter eslint-plugin-zod build`
- `pnpm --filter @eslint-zod/utils build && pnpm --filter eslint-plugin-zod lint:docs`
- `pnpm exec tsc -b plugins/eslint-plugin-zod/tsconfig.json`
